### PR TITLE
[FEATURE #11]: 이미지 업로드/삭제 API 확장 — Spider Admin 연동

### DIFF
--- a/src/app/api/assets/[assetId]/route.ts
+++ b/src/app/api/assets/[assetId]/route.ts
@@ -1,13 +1,15 @@
 // src/app/api/assets/[assetId]/route.ts
 // 에셋 단건 삭제 API
 
+import { unlink } from 'fs/promises';
+
 import { NextRequest } from 'next/server';
 
 import { deleteAsset, getAssetById } from '@/db/repository/asset.repository';
 import { canWriteCms, getCurrentUser } from '@/lib/current-user';
 import { successResponse, errorResponse, getErrorMessage } from '@/lib/api-response';
 
-/** DELETE /api/assets/:assetId — 에셋 논리 삭제 (USE_YN = 'N') */
+/** DELETE /api/assets/:assetId — 에셋 논리 삭제 (USE_YN = 'N') + 물리 파일 삭제 */
 export async function DELETE(req: NextRequest, { params }: { params: Promise<{ assetId: string }> }) {
     try {
         const { assetId } = await params;
@@ -22,7 +24,14 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ a
             return errorResponse('Permission denied.', 403);
         }
         const { userId, userName } = currentUser;
+
+        // DB 논리 삭제
         await deleteAsset(assetId, userId, userName);
+
+        // 물리 파일 삭제 (없어도 무시)
+        if (asset.ASSET_PATH) {
+            await unlink(asset.ASSET_PATH).catch(() => {});
+        }
 
         return successResponse({ deleted: assetId });
     } catch (err: unknown) {

--- a/src/app/api/builder/upload/route.ts
+++ b/src/app/api/builder/upload/route.ts
@@ -27,17 +27,20 @@ export async function POST(req: NextRequest) {
     const businessCategory = formData.get('businessCategory')?.toString() || null;
     const assetDesc = formData.get('assetDesc')?.toString() || null;
 
-    const buffer = Buffer.from(await file.arrayBuffer());
-    const assetId = crypto.randomUUID();
-    const assetName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_');
-
     try {
+        // 권한 체크는 파일 바이트 로드 전에 수행 — 권한 없는 대용량 업로드 조기 차단
         const currentUser = await getCurrentUser();
         if (!canWriteCms(currentUser)) {
             return contentBuilderErrorResponse('Permission denied.');
         }
+
+        // 외부 userId가 주어지면 userName도 외부 값 우선 사용 — 감사 로그 짝 일관성 유지
         const userId = bodyUserId ?? currentUser.userId;
-        const userName = bodyUserName ?? currentUser.userName;
+        const userName = bodyUserId ? (bodyUserName ?? userId) : currentUser.userName;
+
+        const buffer = Buffer.from(await file.arrayBuffer());
+        const assetId = crypto.randomUUID();
+        const assetName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_');
 
         // 파일 시스템에 저장
         const filename = `${assetId}_${assetName}`;

--- a/src/app/api/builder/upload/route.ts
+++ b/src/app/api/builder/upload/route.ts
@@ -21,6 +21,12 @@ export async function POST(req: NextRequest) {
         return contentBuilderErrorResponse('File is required.');
     }
 
+    // Spider Admin 연동용 선택 파라미터 — 없으면 현재 사용자·기본값 사용
+    const bodyUserId = formData.get('userId')?.toString() || null;
+    const bodyUserName = formData.get('userName')?.toString() || null;
+    const businessCategory = formData.get('businessCategory')?.toString() || null;
+    const assetDesc = formData.get('assetDesc')?.toString() || null;
+
     const buffer = Buffer.from(await file.arrayBuffer());
     const assetId = crypto.randomUUID();
     const assetName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_');
@@ -30,7 +36,8 @@ export async function POST(req: NextRequest) {
         if (!canWriteCms(currentUser)) {
             return contentBuilderErrorResponse('Permission denied.');
         }
-        const { userId, userName } = currentUser;
+        const userId = bodyUserId ?? currentUser.userId;
+        const userName = bodyUserName ?? currentUser.userName;
 
         // 파일 시스템에 저장
         const filename = `${assetId}_${assetName}`;
@@ -43,10 +50,12 @@ export async function POST(req: NextRequest) {
             await createAsset({
                 assetId,
                 assetName,
+                businessCategory: businessCategory ?? undefined,
                 mimeType: file.type || 'application/octet-stream',
                 fileSize: buffer.length,
                 assetPath: filepath,
                 assetUrl,
+                assetDesc: assetDesc ?? undefined,
                 createUserId: userId,
                 createUserName: userName,
             });
@@ -56,7 +65,7 @@ export async function POST(req: NextRequest) {
             throw dbErr;
         }
 
-        return successResponse({ url: assetUrl }, 201);
+        return successResponse({ url: assetUrl, assetId }, 201);
     } catch (err: unknown) {
         console.error('File upload failed:', err);
         return contentBuilderErrorResponse(getErrorMessage(err));


### PR DESCRIPTION
## Summary

Spider Admin에서 이미지 업로드/삭제를 담당하게 되면서 CMS API를 보완합니다.

### 업로드 API (`POST /api/builder/upload`)

- 응답에 `assetId` 추가 (Spider Admin이 후속 승인/상태 변경 API 호출 시 사용)
- `multipart/form-data`에 선택 파라미터 4개 수신:
  - `userId`, `userName` — 업로드한 실제 사용자 정보
  - `businessCategory` — 업무 카테고리
  - `assetDesc` — 이미지 설명
- 파라미터 생략 시 기존처럼 CMS 로그인 사용자 정보 사용 (하위 호환)

### 삭제 API (`DELETE /api/assets/{assetId}`)

- 기존 DB 논리 삭제(`USE_YN = 'N'`) + **물리 파일 제거** 추가
- 파일이 없어도 무시하고 성공 처리

## 응답 스펙 변경

**기존:**
```json
{ "url": "/static/파일명" }
```

**변경 후:**
```json
{ "url": "/static/파일명", "assetId": "uuid" }
```

## Test plan

- [x] `npm run build` — 빌드 성공
- [ ] 이미지 업로드 → 응답에 `assetId`, `url` 모두 포함 확인
- [ ] `userId`, `userName`, `businessCategory`, `assetDesc` 포함 업로드 → DB 값 확인
- [ ] 파라미터 생략 업로드 → 현재 사용자 정보로 저장 확인
- [ ] 이미지 삭제 → DB `USE_YN = 'N'` + 물리 파일 제거 확인

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)