### PR TITLE
[FEATURE]: 미승인 에셋은 물리 삭제로 DB row 완전 제거 (#11 follow-up)

### DIFF
--- a/src/app/api/assets/[assetId]/route.ts
+++ b/src/app/api/assets/[assetId]/route.ts
@@ -5,11 +5,16 @@ import { unlink } from 'fs/promises';
 
 import { NextRequest } from 'next/server';
 
-import { deleteAsset, getAssetById } from '@/db/repository/asset.repository';
+import { deleteAsset, getAssetById, hardDeleteAsset } from '@/db/repository/asset.repository';
 import { canWriteCms, getCurrentUser } from '@/lib/current-user';
 import { successResponse, errorResponse, getErrorMessage } from '@/lib/api-response';
 
-/** DELETE /api/assets/:assetId — 에셋 논리 삭제 (USE_YN = 'N') + 물리 파일 삭제 */
+/**
+ * DELETE /api/assets/:assetId — 에셋 삭제
+ * - APPROVED: 논리 삭제 (USE_YN = 'N') — 페이지 참조 보존
+ * - WORK/PENDING/REJECTED: 물리 삭제 (DB row 완전 제거)
+ * - 모든 상태에서 물리 파일은 제거
+ */
 export async function DELETE(req: NextRequest, { params }: { params: Promise<{ assetId: string }> }) {
     try {
         const { assetId } = await params;
@@ -25,15 +30,19 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ a
         }
         const { userId, userName } = currentUser;
 
-        // DB 논리 삭제
-        await deleteAsset(assetId, userId, userName);
+        // 상태별 DB 삭제 처리
+        if (asset.ASSET_STATE === 'APPROVED') {
+            await deleteAsset(assetId, userId, userName);
+        } else {
+            await hardDeleteAsset(assetId);
+        }
 
         // 물리 파일 삭제 (없어도 무시)
         if (asset.ASSET_PATH) {
             await unlink(asset.ASSET_PATH).catch(() => {});
         }
 
-        return successResponse({ deleted: assetId });
+        return successResponse({ deleted: assetId, hardDeleted: asset.ASSET_STATE !== 'APPROVED' });
     } catch (err: unknown) {
         console.error('에셋 삭제 실패:', err);
         return errorResponse(getErrorMessage(err));

--- a/src/db/queries/asset.sql.ts
+++ b/src/db/queries/asset.sql.ts
@@ -69,12 +69,18 @@ export const ASSET_UPDATE_STATE = `
     AND USE_YN = 'Y'
 `;
 
-/** 에셋 논리 삭제 */
+/** 에셋 논리 삭제 (APPROVED 상태 전용 — 페이지 참조 보존) */
 export const ASSET_DELETE = `
   UPDATE SPW_CMS_ASSET
   SET USE_YN = 'N',
       LAST_MODIFIER_ID = :lastModifierId,
       LAST_MODIFIER_NAME = :lastModifierName
+  WHERE ASSET_ID = :assetId
+`;
+
+/** 에셋 물리 삭제 (WORK/PENDING/REJECTED 상태용) */
+export const ASSET_HARD_DELETE = `
+  DELETE FROM SPW_CMS_ASSET
   WHERE ASSET_ID = :assetId
 `;
 

--- a/src/db/queries/asset.sql.ts
+++ b/src/db/queries/asset.sql.ts
@@ -74,7 +74,8 @@ export const ASSET_DELETE = `
   UPDATE SPW_CMS_ASSET
   SET USE_YN = 'N',
       LAST_MODIFIER_ID = :lastModifierId,
-      LAST_MODIFIER_NAME = :lastModifierName
+      LAST_MODIFIER_NAME = :lastModifierName,
+      LAST_MODIFIED_DTIME = SYSTIMESTAMP
   WHERE ASSET_ID = :assetId
 `;
 
@@ -102,6 +103,12 @@ export const ASSET_MAP_SELECT_BY_PAGE = `
 export const ASSET_MAP_INSERT = `
   INSERT INTO SPW_CMS_ASSET_PAGE_MAP (PAGE_ID, VERSION, ASSET_ID)
   VALUES (:pageId, :version, :assetId)
+`;
+
+/** 에셋-페이지 매핑 삭제 (에셋 단위 — 에셋 물리 삭제 시 FK 정리용) */
+export const ASSET_MAP_DELETE_BY_ASSET = `
+  DELETE FROM SPW_CMS_ASSET_PAGE_MAP
+  WHERE ASSET_ID = :assetId
 `;
 
 /** 에셋-페이지 매핑 삭제 (페이지+버전 단위) */

--- a/src/db/repository/asset.repository.ts
+++ b/src/db/repository/asset.repository.ts
@@ -13,6 +13,7 @@ import {
     ASSET_INSERT,
     ASSET_UPDATE_STATE,
     ASSET_DELETE,
+    ASSET_HARD_DELETE,
     ASSET_MAP_SELECT_BY_PAGE,
     ASSET_MAP_INSERT,
     ASSET_MAP_DELETE_BY_PAGE_VERSION,
@@ -124,7 +125,7 @@ export async function updateAssetState(
     });
 }
 
-/** 에셋 논리 삭제 */
+/** 에셋 논리 삭제 (APPROVED 상태용 — 페이지 참조 보존) */
 export async function deleteAsset(assetId: string, lastModifierId: string, lastModifierName: string): Promise<void> {
     await withTransaction(async (conn) => {
         await conn.execute(ASSET_DELETE, {
@@ -132,6 +133,13 @@ export async function deleteAsset(assetId: string, lastModifierId: string, lastM
             lastModifierId,
             lastModifierName,
         });
+    });
+}
+
+/** 에셋 물리 삭제 (WORK/PENDING/REJECTED 상태용 — DB row 완전 제거) */
+export async function hardDeleteAsset(assetId: string): Promise<void> {
+    await withTransaction(async (conn) => {
+        await conn.execute(ASSET_HARD_DELETE, { assetId });
     });
 }
 

--- a/src/db/repository/asset.repository.ts
+++ b/src/db/repository/asset.repository.ts
@@ -16,6 +16,7 @@ import {
     ASSET_HARD_DELETE,
     ASSET_MAP_SELECT_BY_PAGE,
     ASSET_MAP_INSERT,
+    ASSET_MAP_DELETE_BY_ASSET,
     ASSET_MAP_DELETE_BY_PAGE_VERSION,
 } from '@/db/queries/asset.sql';
 
@@ -136,9 +137,13 @@ export async function deleteAsset(assetId: string, lastModifierId: string, lastM
     });
 }
 
-/** 에셋 물리 삭제 (WORK/PENDING/REJECTED 상태용 — DB row 완전 제거) */
+/**
+ * 에셋 물리 삭제 (WORK/PENDING/REJECTED 상태용 — DB row 완전 제거)
+ * FK/orphan 방지를 위해 ASSET_PAGE_MAP 참조를 먼저 정리한 뒤 에셋 삭제 (같은 트랜잭션)
+ */
 export async function hardDeleteAsset(assetId: string): Promise<void> {
     await withTransaction(async (conn) => {
+        await conn.execute(ASSET_MAP_DELETE_BY_ASSET, { assetId });
         await conn.execute(ASSET_HARD_DELETE, { assetId });
     });
 }


### PR DESCRIPTION
## Summary

PR #12 머지 후 추가된 후속 개선 — 미승인 상태 에셋 삭제 시 DB row 완전 제거.

## 변경 배경

삭제 API 테스트 중 발견: DB 논리 삭제(`USE_YN = 'N'`)만 수행되어 미승인 에셋 row가 DB에 계속 누적됨. APPROVED 상태는 페이지 참조 때문에 유지 필요하지만, WORK/PENDING/REJECTED는 완전 삭제해도 무방.

## 삭제 정책 분기

| ASSET_STATE | 처리 |
|---|---|
| APPROVED | 기존처럼 논리 삭제 (`USE_YN = 'N'`) — 페이지 참조 보존 |
| WORK / PENDING / REJECTED | **물리 삭제** (DB row 완전 제거) |
| (모든 상태) | 물리 파일은 `/data/uploads/`에서 제거 |

## 변경 파일

- `src/db/queries/asset.sql.ts` — `ASSET_HARD_DELETE` SQL 추가
- `src/db/repository/asset.repository.ts` — `hardDeleteAsset()` 함수 추가
- `src/app/api/assets/[assetId]/route.ts` — `ASSET_STATE`에 따라 분기
- 응답에 `hardDeleted` 플래그 추가

## Test plan

- [x] `npm run build` — 빌드 성공
- [ ] WORK 상태 업로드 → DELETE → DB row 제거 + 파일 제거 확인
- [ ] APPROVED 상태 → DELETE → DB `USE_YN='N'` + 파일 제거 확인

Related: #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)