### PR TITLE
[FEATURE #17]: 이미지 승인 파일 복사 API 구현

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -46,6 +46,10 @@ GEMINI_API_KEY=
 ASSET_UPLOAD_DIR=/app/public/uploads
 ASSET_BASE_URL=/static
 
+# ── 배포 저장소 (승인 완료 이미지) ──────────────────────────────────────────
+DEPLOYED_UPLOAD_DIR=/app/public/deployed
+DEPLOYED_BASE_URL=/deployed/static
+
 
 # ── 인증 우회 (테스트용) ─────────────────────────────────────────────────────
 # true: admin 로그인 없이 CMS 접근 허용 (개발·테스트 환경 전용)

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -33,6 +33,7 @@ services:
     volumes:
       # 호스트 바인드 마운트 — nginx 정적 서빙 공유용
       - /data/uploads:/app/public/uploads
+      - /data/deployed:/app/public/deployed   # 승인 이미지 복사 대상 + :3000 에디터 읽기용
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:3000/cms/api/health || exit 1"]
       interval: 30s

--- a/src/app/api/assets/[assetId]/deploy/route.ts
+++ b/src/app/api/assets/[assetId]/deploy/route.ts
@@ -1,0 +1,75 @@
+// src/app/api/assets/[assetId]/deploy/route.ts
+// 승인된 에셋의 파일을 uploads → deployed/img 로 이동 + DB 경로 업데이트
+//
+// 흐름:
+//   1. 에셋 조회 (없으면 404)
+//   2. ASSET_STATE === 'APPROVED' 검증 (아니면 400)
+//   3. 원본 파일 존재 확인 (없으면 404)
+//   4. DEPLOYED_UPLOAD_DIR/img/ 로 복사 (mkdir recursive)
+//   5. 원본 삭제 (실패해도 복사는 성공)
+//   6. DB ASSET_PATH, ASSET_URL 업데이트
+
+import { access, copyFile, mkdir, unlink } from 'fs/promises';
+import { basename, join } from 'path';
+
+import { NextRequest } from 'next/server';
+
+import { getAssetById, updateAssetPathUrl } from '@/db/repository/asset.repository';
+import { successResponse, errorResponse, getErrorMessage } from '@/lib/api-response';
+import { canWriteCms, getCurrentUser } from '@/lib/current-user';
+import { DEPLOYED_UPLOAD_DIR, DEPLOYED_BASE_URL } from '@/lib/env';
+
+/** POST /api/assets/:assetId/deploy — 승인된 이미지 파일 이동 */
+export async function POST(req: NextRequest, { params }: { params: Promise<{ assetId: string }> }) {
+    try {
+        const { assetId } = await params;
+
+        const currentUser = await getCurrentUser();
+        if (!canWriteCms(currentUser)) {
+            return errorResponse('Permission denied.', 403);
+        }
+
+        const asset = await getAssetById(assetId);
+        if (!asset) {
+            return errorResponse('에셋을 찾을 수 없습니다.', 404);
+        }
+
+        if (asset.ASSET_STATE !== 'APPROVED') {
+            return errorResponse(`승인되지 않은 에셋입니다. (현재 상태: ${asset.ASSET_STATE})`, 400);
+        }
+
+        if (!asset.ASSET_PATH) {
+            return errorResponse('에셋 경로 정보가 없습니다.', 500);
+        }
+
+        // 원본 파일 존재 확인
+        try {
+            await access(asset.ASSET_PATH);
+        } catch {
+            return errorResponse('원본 파일을 찾을 수 없습니다.', 404);
+        }
+
+        // 대상 경로 계산
+        const filename = basename(asset.ASSET_PATH);
+        const deployedImgDir = join(DEPLOYED_UPLOAD_DIR, 'img');
+        const deployedPath = join(deployedImgDir, filename);
+        const deployedUrl = `${DEPLOYED_BASE_URL}/${filename}`;
+
+        // 대상 디렉토리 생성 + 파일 복사
+        await mkdir(deployedImgDir, { recursive: true });
+        await copyFile(asset.ASSET_PATH, deployedPath);
+
+        // DB 경로·URL 업데이트 (복사 성공 후)
+        await updateAssetPathUrl(assetId, deployedPath, deployedUrl);
+
+        // 원본 파일 삭제 (실패해도 복사는 성공이므로 경고만)
+        await unlink(asset.ASSET_PATH).catch((err) => {
+            console.warn(`원본 파일 삭제 실패 (${asset.ASSET_PATH}):`, err);
+        });
+
+        return successResponse({ url: deployedUrl });
+    } catch (err: unknown) {
+        console.error('에셋 배포 실패:', err);
+        return errorResponse(getErrorMessage(err));
+    }
+}

--- a/src/app/api/assets/[assetId]/deploy/route.ts
+++ b/src/app/api/assets/[assetId]/deploy/route.ts
@@ -55,12 +55,17 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ ass
         const deployedPath = join(deployedImgDir, filename);
         const deployedUrl = `${DEPLOYED_BASE_URL}/${filename}`;
 
+        // 멱등성 — 이미 배포된 경로면 조기 반환 (중복 호출 시 unlink 로 배포 파일 삭제되는 사고 방지)
+        if (asset.ASSET_PATH === deployedPath) {
+            return successResponse({ url: deployedUrl });
+        }
+
         // 대상 디렉토리 생성 + 파일 복사
         await mkdir(deployedImgDir, { recursive: true });
         await copyFile(asset.ASSET_PATH, deployedPath);
 
         // DB 경로·URL 업데이트 (복사 성공 후)
-        await updateAssetPathUrl(assetId, deployedPath, deployedUrl);
+        await updateAssetPathUrl(assetId, deployedPath, deployedUrl, currentUser.userId, currentUser.userName);
 
         // 원본 파일 삭제 (실패해도 복사는 성공이므로 경고만)
         await unlink(asset.ASSET_PATH).catch((err) => {

--- a/src/db/queries/asset.sql.ts
+++ b/src/db/queries/asset.sql.ts
@@ -69,6 +69,16 @@ export const ASSET_UPDATE_STATE = `
     AND USE_YN = 'Y'
 `;
 
+/** 에셋 파일 경로·URL 업데이트 (승인 후 파일 이동 시 사용) */
+export const ASSET_UPDATE_PATH_URL = `
+  UPDATE SPW_CMS_ASSET
+  SET ASSET_PATH = :assetPath,
+      ASSET_URL = :assetUrl,
+      LAST_MODIFIED_DTIME = SYSTIMESTAMP
+  WHERE ASSET_ID = :assetId
+    AND USE_YN = 'Y'
+`;
+
 /** 에셋 논리 삭제 (APPROVED 상태 전용 — 페이지 참조 보존) */
 export const ASSET_DELETE = `
   UPDATE SPW_CMS_ASSET

--- a/src/db/queries/asset.sql.ts
+++ b/src/db/queries/asset.sql.ts
@@ -74,6 +74,8 @@ export const ASSET_UPDATE_PATH_URL = `
   UPDATE SPW_CMS_ASSET
   SET ASSET_PATH = :assetPath,
       ASSET_URL = :assetUrl,
+      LAST_MODIFIER_ID = :lastModifierId,
+      LAST_MODIFIER_NAME = :lastModifierName,
       LAST_MODIFIED_DTIME = SYSTIMESTAMP
   WHERE ASSET_ID = :assetId
     AND USE_YN = 'Y'

--- a/src/db/repository/asset.repository.ts
+++ b/src/db/repository/asset.repository.ts
@@ -12,6 +12,7 @@ import {
     ASSET_COUNT,
     ASSET_INSERT,
     ASSET_UPDATE_STATE,
+    ASSET_UPDATE_PATH_URL,
     ASSET_DELETE,
     ASSET_HARD_DELETE,
     ASSET_MAP_SELECT_BY_PAGE,
@@ -123,6 +124,13 @@ export async function updateAssetState(
 ): Promise<void> {
     await withTransaction(async (conn) => {
         await conn.execute(ASSET_UPDATE_STATE, { assetId, assetState, lastModifierId, lastModifierName });
+    });
+}
+
+/** 에셋 파일 경로·URL 업데이트 (승인 후 파일 이동 시 사용) */
+export async function updateAssetPathUrl(assetId: string, assetPath: string, assetUrl: string): Promise<void> {
+    await withTransaction(async (conn) => {
+        await conn.execute(ASSET_UPDATE_PATH_URL, { assetId, assetPath, assetUrl });
     });
 }
 

--- a/src/db/repository/asset.repository.ts
+++ b/src/db/repository/asset.repository.ts
@@ -128,9 +128,21 @@ export async function updateAssetState(
 }
 
 /** 에셋 파일 경로·URL 업데이트 (승인 후 파일 이동 시 사용) */
-export async function updateAssetPathUrl(assetId: string, assetPath: string, assetUrl: string): Promise<void> {
+export async function updateAssetPathUrl(
+    assetId: string,
+    assetPath: string,
+    assetUrl: string,
+    lastModifierId: string,
+    lastModifierName: string,
+): Promise<void> {
     await withTransaction(async (conn) => {
-        await conn.execute(ASSET_UPDATE_PATH_URL, { assetId, assetPath, assetUrl });
+        await conn.execute(ASSET_UPDATE_PATH_URL, {
+            assetId,
+            assetPath,
+            assetUrl,
+            lastModifierId,
+            lastModifierName,
+        });
     });
 }
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -36,6 +36,10 @@ export const SERVER_MODE = optionalEnv('SERVER_MODE', 'cms');
 export const ASSET_UPLOAD_DIR = optionalEnv('ASSET_UPLOAD_DIR', 'public/uploads');
 export const ASSET_BASE_URL = optionalEnv('ASSET_BASE_URL', '/uploads');
 
+// ── 배포 저장소 (승인 완료 이미지) ──
+export const DEPLOYED_UPLOAD_DIR = optionalEnv('DEPLOYED_UPLOAD_DIR', 'public/deployed');
+export const DEPLOYED_BASE_URL = optionalEnv('DEPLOYED_BASE_URL', '/deployed/static');
+
 // ── 브랜드 테마 ──
 export const BANK_BRAND = optionalEnv('BANK_BRAND', '');
 


### PR DESCRIPTION
## Summary

Spider Admin이 이미지 승인 완료 후 호출할 파일 이동 API를 구현합니다.

## API 스펙

```
POST {CMS_BASE_URL}/cms/api/assets/{assetId}/deploy
```

**응답 성공:**
```json
{ "ok": true, "data": { "url": "/deployed/static/{파일명}" } }
```

**응답 실패 케이스:**
- `404`: 에셋 없음 / 원본 파일 없음
- `400`: ASSET_STATE가 'APPROVED'가 아님
- `403`: CMS:W 권한 없음
- `500`: 파일 복사 실패 / 경로 정보 없음

## 동작 흐름

1. 에셋 조회 (`ASSET_STATE === 'APPROVED'` 검증)
2. 원본 파일 존재 확인
3. `/data/deployed/img/` 디렉토리 생성 (없으면)
4. 파일 복사 (`uploads/xxx` → `deployed/img/xxx`)
5. DB `ASSET_PATH`, `ASSET_URL` 업데이트
6. 원본 파일 삭제 (실패해도 복사 성공이면 진행)

## 변경 파일

- `src/app/api/assets/[assetId]/deploy/route.ts` — 신규 API
- `src/lib/env.ts` — `DEPLOYED_UPLOAD_DIR`, `DEPLOYED_BASE_URL` 환경변수 추가
- `src/db/queries/asset.sql.ts` — `ASSET_UPDATE_PATH_URL` SQL 추가
- `src/db/repository/asset.repository.ts` — `updateAssetPathUrl()` 함수 추가
- `docker-compose-prod.yml` — cms 서비스에 `/data/deployed` 마운트 추가
- `.env.prod.example` — `DEPLOYED_*` 환경변수 문서화

## 인프라 변경

`:3000` 컨테이너에도 `/data/deployed` 마운트 추가 — :3000 에디터에서 승인 이미지 조회 가능.
nginx `/deployed/static/` 경로는 이미 양쪽 포트(80, 8080)에 설정되어 있어 추가 작업 없음.

## Test plan

- [x] `npm run build` — 빌드 성공
- [ ] 이미지 업로드 후 수동으로 ASSET_STATE='APPROVED' UPDATE
- [ ] `curl -X POST {CMS}/cms/api/assets/{assetId}/deploy` → 200 응답 확인
- [ ] `/data/deployed/img/` 에 파일 생성, `/data/uploads/` 에서 삭제 확인
- [ ] DB `ASSET_PATH`, `ASSET_URL` 업데이트 확인
- [ ] `/deployed/static/{파일명}` URL 로 이미지 조회 가능 확인
- [ ] 미승인 상태에서 호출 시 400 반환 확인

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)