### PR TITLE
fix: push API에 x-deploy-token 서버 간 인증 추가

### DIFF
--- a/src/app/api/deploy/push/route.ts
+++ b/src/app/api/deploy/push/route.ts
@@ -11,6 +11,8 @@ import { PAGE_SELECT_BY_ID } from '@/db/queries/page.sql';
 import { upsertFileSend, getServerList } from '@/db/repository/file-send.repository';
 import { updatePageDeploy, getLatestHistory, getHistoryVersionByFilePath } from '@/db/repository/page.repository';
 import type { CmsPage } from '@/db/types';
+import { timingSafeEqual } from 'crypto';
+
 import { canWriteCms, getCurrentUser } from '@/lib/current-user';
 import { errorResponse, getErrorMessage, successResponse } from '@/lib/api-response';
 import { sendToServer } from '@/lib/deploy-utils';
@@ -18,6 +20,20 @@ import { sendToServer } from '@/lib/deploy-utils';
 const OBJ = { outFormat: oracledb.OUT_FORMAT_OBJECT };
 
 const CMS_BASE_URL = process.env.CMS_BASE_URL || 'http://localhost:3000';
+const DEPLOY_SECRET = process.env.DEPLOY_SECRET ?? '';
+
+/** 타이밍 공격 방지 토큰 비교 — spider-admin 서버 간 호출 인증용 */
+function isValidToken(token: string | null): boolean {
+    if (!DEPLOY_SECRET || !token) return false;
+    try {
+        const expected = Buffer.from(DEPLOY_SECRET, 'utf8');
+        const received = Buffer.from(token, 'utf8');
+        if (expected.length !== received.length) return false;
+        return timingSafeEqual(expected, received);
+    } catch {
+        return false;
+    }
+}
 
 /** CRC32 대신 SHA-256 앞 16자리로 무결성 값 생성 */
 function calcCrc(content: string): string {
@@ -126,12 +142,21 @@ ${html}
 
 export async function POST(req: NextRequest) {
     try {
-        const { pageId } = (await req.json()) as { pageId?: string };
-        const currentUser = await getCurrentUser();
-        if (!canWriteCms(currentUser)) {
-            return errorResponse('권한이 없습니다.', 403);
+        const body = (await req.json()) as { pageId?: string; userId?: string };
+        const { pageId } = body;
+
+        // spider-admin 서버 간 호출(x-deploy-token) 또는 일반 사용자 세션 인증
+        let userId: string;
+        if (isValidToken(req.headers.get('x-deploy-token'))) {
+            // 서버 간 호출 — userId는 요청 body에서 전달받음 (없으면 'system' 사용)
+            userId = body.userId || 'system';
+        } else {
+            const currentUser = await getCurrentUser();
+            if (!canWriteCms(currentUser)) {
+                return errorResponse('권한이 없습니다.', 403);
+            }
+            userId = currentUser.userId;
         }
-        const { userId } = currentUser;
 
         if (!pageId || typeof pageId !== 'string') {
             return errorResponse('pageId가 필요합니다.', 400);


### PR DESCRIPTION
## Summary
- spider-admin에서 CMS push API를 직접 호출할 수 있도록 `x-deploy-token` 서버 간 인증 경로 추가
- 기존 사용자 세션 인증은 그대로 유지

## 변경 내역
`src/app/api/deploy/push/route.ts`
- `isValidToken()` 함수 추가 (`receive/route.ts`와 동일한 타이밍 공격 방지 비교)
- `x-deploy-token` 헤더 유효 시 세션 검사 없이 통과, `userId`는 request body에서 수신
- 기존 사용자 세션 인증 흐름은 변경 없음

## 배경
spider-admin이 직접 receive API를 호출할 경우 `PAGE_HTML`(raw fragment)이 ContentBuilder CSS·런타임 없이 배포되어 컴포넌트가 렌더링되지 않는 문제가 있었음. admin이 CMS push API를 호출하도록 변경하여 HTML 조립을 CMS에 위임.

## 관련 PR
- POC_HNC bug/#86 (spider-admin 측 변경)

## Test plan
- [ ] `x-deploy-token` 헤더 없이 호출 시 기존과 동일하게 세션 인증이 적용된다
- [ ] 유효한 `x-deploy-token`으로 호출 시 세션 없이 배포가 실행된다
- [ ] 잘못된 토큰으로 호출 시 403이 반환된다

🤖 Generated with [Claude Code](https://claude.com/claude-code)