### PR TITLE
[CHORE]: Oracle 커넥션 풀 poolMax 5 → 3 축소

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,8 @@ ORACLE_HOST=
 ORACLE_PORT=1521
 ORACLE_SERVICE=XE
 ORACLE_SCHEMA=
+# 커넥션 풀 최대 크기 (기본 3) — 공유 Oracle XE 환경에서 타 서비스 세션 여유 확보
+ORACLE_POOL_MAX=3
 
 # ── 보안 ──
 # JWT 서명 키 — 로그인 토큰 발급·검증에 사용. 충분히 길고 랜덤한 문자열로 설정.

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -20,6 +20,8 @@ ORACLE_HOST=                # 개발 DB 서버 IP 또는 도메인
 ORACLE_PORT=1521
 ORACLE_SERVICE=XE
 ORACLE_SCHEMA=
+# 커넥션 풀 최대 크기 (기본 3) — 공유 Oracle XE 환경에서 타 서비스 세션 여유 확보
+ORACLE_POOL_MAX=3
 
 # ── 보안 ────────────────────────────────────────────────────────────────────
 # 생성: openssl rand -hex 32

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -2,7 +2,15 @@
 
 import oracledb from 'oracledb';
 
-import { ORACLE_USER, ORACLE_PASSWORD, ORACLE_HOST, ORACLE_PORT, ORACLE_SERVICE, ORACLE_SCHEMA } from '@/lib/env';
+import {
+    ORACLE_USER,
+    ORACLE_PASSWORD,
+    ORACLE_HOST,
+    ORACLE_PORT,
+    ORACLE_SERVICE,
+    ORACLE_SCHEMA,
+    ORACLE_POOL_MAX,
+} from '@/lib/env';
 
 let poolInitPromise: Promise<void> | null = null;
 
@@ -23,7 +31,7 @@ async function initPool(): Promise<void> {
                 password: ORACLE_PASSWORD,
                 connectString: `${ORACLE_HOST}:${ORACLE_PORT}/${ORACLE_SERVICE}`,
                 poolMin: 0, // 공유 Oracle XE 세션 제한 고려 (최대 20개)
-                poolMax: 3, // 공유 DB 환경에서 ORA-12516 방지 — Spider Admin 등 타 서비스 세션 여유 확보
+                poolMax: ORACLE_POOL_MAX, // 기본 3 — 공유 DB 환경에서 ORA-12516 방지 (env 로 조정 가능)
                 poolIncrement: 1,
                 poolTimeout: 60, // 1분: 유휴 커넥션 빠른 반환 (Oracle XE 세션 제한 대응)
                 queueTimeout: 30000, // 30초: 커넥션 부족 시 대기 시간 확보

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -23,7 +23,7 @@ async function initPool(): Promise<void> {
                 password: ORACLE_PASSWORD,
                 connectString: `${ORACLE_HOST}:${ORACLE_PORT}/${ORACLE_SERVICE}`,
                 poolMin: 0, // 공유 Oracle XE 세션 제한 고려 (최대 20개)
-                poolMax: 5,
+                poolMax: 3, // 공유 DB 환경에서 ORA-12516 방지 — Spider Admin 등 타 서비스 세션 여유 확보
                 poolIncrement: 1,
                 poolTimeout: 60, // 1분: 유휴 커넥션 빠른 반환 (Oracle XE 세션 제한 대응)
                 queueTimeout: 30000, // 30초: 커넥션 부족 시 대기 시간 확보

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -56,3 +56,5 @@ export const ORACLE_HOST = optionalEnv('ORACLE_HOST');
 export const ORACLE_PORT = optionalEnv('ORACLE_PORT', '1521');
 export const ORACLE_SERVICE = optionalEnv('ORACLE_SERVICE');
 export const ORACLE_SCHEMA = optionalEnv('ORACLE_SCHEMA');
+/** Oracle 커넥션 풀 최대 크기 (공유 XE 세션 제한 대응 — 기본 3) */
+export const ORACLE_POOL_MAX = Number(optionalEnv('ORACLE_POOL_MAX', '3'));


### PR DESCRIPTION
## Summary

공유 Oracle XE 환경에서 `ORA-12516` (리스너 핸들러 부족) 에러가 발생해서, CMS 가 점유하는 커넥션 수를 줄여 타 서비스(Spider Admin 등) 세션 여유를 확보합니다.

## 변경 내용

`src/db/connection.ts`:
- `poolMax: 5` → `poolMax: 3`

## 근거

- CMS 내부 API 는 단발성 쿼리 위주 → 3개로도 충분
- `queueTimeout: 30000` (30초) 대기 여유 있어 일시적 peak 부하 대응 가능
- 공유 DB 환경에서 CMS :3000 + :3001 = 최대 6 커넥션 → 10 커넥션 사용 중이었음
- 축소 후 최대 6 커넥션으로 제한됨

## 배경

Spider Admin 이미지 승인 연동 테스트 중 `ORA-12516` 발생.
DBA 접근 권한 없어 근본 해결(Oracle `processes` 상향) 어려움 — CMS 쪽 선제 대응.

## Test plan

- [x] 빌드 성공
- [ ] 배포 후 API 정상 동작 확인 (단건 요청)
- [ ] 동시 다중 요청 시 queueTimeout 내 처리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)