### PR TITLE
fix: 운영 서버 배포 URL basePath(/cms) 누락 수정

### DIFF
--- a/src/app/api/deploy/push/route.ts
+++ b/src/app/api/deploy/push/route.ts
@@ -242,7 +242,7 @@ async function processDeploy(pageId: string | undefined, userId: string) {
     // 5. 각 서버에 병렬 전송 + 이력 기록
     const results = await Promise.all(
         servers.map(async (server) => {
-            const serverUrl = `http://${server.INSTANCE_IP}:${server.INSTANCE_PORT}/api/deploy/receive`;
+            const serverUrl = `http://${server.INSTANCE_IP}:${server.INSTANCE_PORT}/cms/api/deploy/receive`;
             try {
                 await sendToServer(serverUrl, pageId, html, trackerJs);
                 await upsertFileSend({

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -38,7 +38,7 @@ async function deployExpiredPage(pageId: string): Promise<void> {
 
     await Promise.all(
         servers.map(async (server) => {
-            const serverUrl = `http://${server.INSTANCE_IP}:${server.INSTANCE_PORT}/api/deploy/receive`;
+            const serverUrl = `http://${server.INSTANCE_IP}:${server.INSTANCE_PORT}/cms/api/deploy/receive`;
             try {
                 await sendToServer(serverUrl, pageId, expiredHtml);
                 await upsertFileSend({


### PR DESCRIPTION
## Summary
- `deploy/push` 및 만료 스케줄러에서 운영 서버 호출 시 URL에 basePath(`/cms`)가 누락되어 404 발생
- `/api/deploy/receive` → `/cms/api/deploy/receive` 로 수정 (2곳)
  - `src/app/api/deploy/push/route.ts`
  - `src/lib/scheduler.ts`

## 원인
운영 서버도 동일한 Next.js 앱(`basePath: '/cms'`)으로 실행되므로, `/api/deploy/receive` 경로가 존재하지 않아 Next.js 404 페이지가 반환됨 → `successCount: 0` → DB 이력 미적재

## Test plan
- [ ] `POST /cms/api/deploy/push` 호출 후 `successCount > 0` 확인
- [ ] `FWK_CMS_FILE_SEND_HIS` 테이블에 이력 INSERT 확인
- [ ] 만료 스케줄러(`/api/batch/execute`) 실행 후 만료 페이지 운영 서버 전송 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)