### PR TITLE
[FEATURE #33]: 승인 이미지 브라우저 복구·개조

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,17 @@ GEMINI_API_KEY=
 ASSET_UPLOAD_DIR=public/uploads
 ASSET_BASE_URL=/uploads
 
+# ── 배포 저장소 (승인 완료 이미지) ──
+# Spider Admin 에서 승인된 이미지가 복사되는 경로 + 에디터에서 선택할 때 조회하는 루트.
+# 로컬 개발에서 이미지 렌더를 확인하려면 DEPLOYED_BASE_URL 을 파일시스템과 맞춰야 함.
+#   예) DEPLOYED_UPLOAD_DIR=public/deployed + DEPLOYED_BASE_URL=/deployed
+# 운영 배포: /data/deployed 볼륨 + /deployed/static nginx 리라이트
+DEPLOYED_UPLOAD_DIR=public/deployed
+DEPLOYED_BASE_URL=/deployed/static
+# 승인 이미지 서브 디렉토리명 (기본: img)
+# 변경 시 Spider Admin·nginx 설정과 함께 맞춰야 함
+DEPLOYED_IMG_SUBDIR=img
+
 # ── Oracle DB (필수) ──
 # 페이지 저장/로드, 금융 컴포넌트 등 모든 데이터를 DB에서 관리.
 # Oracle Instant Client가 설치되어 있어야 함 (Thick 모드).
@@ -67,10 +78,6 @@ ORACLE_SCHEMA=
 ORACLE_POOL_MAX=3
 
 # ── 보안 ──
-# JWT 서명 키 — 로그인 토큰 발급·검증에 사용. 충분히 길고 랜덤한 문자열로 설정.
-# 예: openssl rand -hex 32
-JWT_SECRET=
-
 # 배포 수신 토큰 — CMS 서버와 운영 서버가 동일한 값을 공유해야 함.
 # /api/deploy/receive 호출 시 x-deploy-token 헤더로 전달.
 # 예: openssl rand -hex 32
@@ -125,3 +132,22 @@ ENABLE_INTERNAL_SCHEDULER=true
 # node-cron 형식: "초(옵션) 분 시 일 월 요일"
 # SCHEDULER_CRON=0 0 * * *
 
+# ── Spider Admin / Java admin 연동 (AUTH_BYPASS=false 인 경우 필수) ──
+# Spider Admin 서버 베이스 URL — 인증(/api/auth/me), 승인자 목록 등 조회에 사용
+# 세 변수 중 하나만 있으면 됨 (우선순위: CMS_ADMIN_BASE_URL > SPIDER_ADMIN_BASE_URL > JAVA_ADMIN_API_BASE_URL)
+# 예) https://admin.neobns.com
+CMS_ADMIN_BASE_URL=
+SPIDER_ADMIN_BASE_URL=
+JAVA_ADMIN_API_BASE_URL=
+
+# 승인자 목록 조회 엔드포인트 경로 (기본: /api/auth/cms-approvers)
+# JAVA_ADMIN_CMS_APPROVERS_PATH=/api/auth/cms-approvers
+
+# ── 클라이언트 번들 공개 변수 (NEXT_PUBLIC_*) ──
+# 브라우저까지 노출되는 변수. 민감 정보 넣지 말 것.
+# basePath — next.config.ts 와 동일하게 설정 (기본: /cms)
+NEXT_PUBLIC_CMS_BASE_PATH=/cms
+# Java admin API 베이스 URL — 프론트 fetch 에서 사용
+NEXT_PUBLIC_JAVA_API_BASE_URL=
+# Spider Admin UI 베이스 URL — 상단 네비·외부 링크 용
+NEXT_PUBLIC_SPIDER_ADMIN_BASE_URL=

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -25,7 +25,6 @@ ORACLE_POOL_MAX=3
 
 # ── 보안 ────────────────────────────────────────────────────────────────────
 # 생성: openssl rand -hex 32
-JWT_SECRET=
 DEPLOY_SECRET=              # CMS 컨테이너와 운영 컨테이너 반드시 동일한 값 사용
 SCHEDULER_SECRET=
 
@@ -51,6 +50,9 @@ ASSET_BASE_URL=/static
 # ── 배포 저장소 (승인 완료 이미지) ──────────────────────────────────────────
 DEPLOYED_UPLOAD_DIR=/app/public/deployed
 DEPLOYED_BASE_URL=/deployed/static
+# 승인 이미지 서브 디렉토리명 — 승인 시 파일 복사 대상 + 에디터 이미지 브라우저 루트
+# 변경 시 Spider Admin·nginx 설정과 동일하게 맞춰야 함 (기본: img)
+DEPLOYED_IMG_SUBDIR=img
 
 
 # ── 인증 우회 (테스트용) ─────────────────────────────────────────────────────
@@ -66,3 +68,31 @@ GIT_AUTO_COMMIT=false
 GIT_USER_NAME=Springware CMS
 GIT_USER_EMAIL=cms@springware.local
 GIT_BRANCH=main
+
+# ── Spider Admin / Java admin 연동 (AUTH_BYPASS=true 유지 중이면 생략 가능) ──
+# Spider Admin 서버 베이스 URL — 우선순위: CMS_ADMIN_BASE_URL > SPIDER_ADMIN_BASE_URL > JAVA_ADMIN_API_BASE_URL
+CMS_ADMIN_BASE_URL=
+SPIDER_ADMIN_BASE_URL=
+JAVA_ADMIN_API_BASE_URL=
+# 승인자 목록 엔드포인트 (기본: /api/auth/cms-approvers)
+# JAVA_ADMIN_CMS_APPROVERS_PATH=/api/auth/cms-approvers
+
+# ── 클라이언트 번들 공개 변수 (NEXT_PUBLIC_*) ──
+# basePath — next.config.ts 와 동일해야 함 (기본: /cms)
+NEXT_PUBLIC_CMS_BASE_PATH=/cms
+# 브라우저에서 Java admin API 직접 호출 시 사용
+NEXT_PUBLIC_JAVA_API_BASE_URL=
+# Spider Admin UI 링크 베이스 (상단 네비·외부 링크용)
+NEXT_PUBLIC_SPIDER_ADMIN_BASE_URL=
+
+# ── 배치 실행 (spider-admin 연동) ──────────────────────────────────────────
+# spider-admin BatchExecService 가 FWK_BATCH_HIS 에 기록할 인스턴스 식별자
+# 다중 CMS 인스턴스 운영 시 각 서버에 고유 값 설정 (예: CMS-01, CMS-02)
+CMS_INSTANCE_ID=CMS-01
+
+# 내장 스케줄러 활성화 여부 (기본: true)
+# 다중 인스턴스 운영 시 하나만 true, 나머지는 false
+ENABLE_INTERNAL_SCHEDULER=true
+
+# 내장 스케줄러 CRON 표현식 (기본: 매일 자정) — node-cron 형식
+# SCHEDULER_CRON=0 0 * * *

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@
 /public/uploads/*
 !/public/uploads/pages/
 
+# ── 배포 저장소 (승인 완료 이미지) ──
+# Spider Admin 승인 시 복사되는 파일 — 런타임 데이터
+/public/deployed/
+
 # ── 저장된 콘텐츠 데이터 ──
 # 에디터에서 저장된 페이지 데이터 (운영 환경마다 다름)
 /data/index.json

--- a/src/app/api/assets/[assetId]/deploy/route.ts
+++ b/src/app/api/assets/[assetId]/deploy/route.ts
@@ -1,11 +1,11 @@
 // src/app/api/assets/[assetId]/deploy/route.ts
-// 승인된 에셋의 파일을 uploads → deployed/img 로 이동 + DB 경로 업데이트
+// 승인된 에셋의 파일을 uploads → deployed/<DEPLOYED_IMG_SUBDIR> 로 이동 + DB 경로 업데이트
 //
 // 흐름:
 //   1. 에셋 조회 (없으면 404)
 //   2. ASSET_STATE === 'APPROVED' 검증 (아니면 400)
 //   3. 원본 파일 존재 확인 (없으면 404)
-//   4. DEPLOYED_UPLOAD_DIR/img/ 로 복사 (mkdir recursive)
+//   4. DEPLOYED_UPLOAD_DIR/<DEPLOYED_IMG_SUBDIR>/ 로 복사 (mkdir recursive)
 //   5. 원본 삭제 (실패해도 복사는 성공)
 //   6. DB ASSET_PATH, ASSET_URL 업데이트
 
@@ -17,7 +17,7 @@ import { NextRequest } from 'next/server';
 import { getAssetById, updateAssetPathUrl } from '@/db/repository/asset.repository';
 import { successResponse, errorResponse, getErrorMessage } from '@/lib/api-response';
 import { canWriteCms, getCurrentUser } from '@/lib/current-user';
-import { DEPLOYED_UPLOAD_DIR, DEPLOYED_BASE_URL } from '@/lib/env';
+import { DEPLOYED_UPLOAD_DIR, DEPLOYED_BASE_URL, DEPLOYED_IMG_SUBDIR } from '@/lib/env';
 
 /** POST /api/assets/:assetId/deploy — 승인된 이미지 파일 이동 */
 export async function POST(req: NextRequest, { params }: { params: Promise<{ assetId: string }> }) {
@@ -51,7 +51,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ ass
 
         // 대상 경로 계산
         const filename = basename(asset.ASSET_PATH);
-        const deployedImgDir = join(DEPLOYED_UPLOAD_DIR, 'img');
+        const deployedImgDir = join(DEPLOYED_UPLOAD_DIR, DEPLOYED_IMG_SUBDIR);
         const deployedPath = join(deployedImgDir, filename);
         const deployedUrl = `${DEPLOYED_BASE_URL}/${filename}`;
 

--- a/src/app/api/manage/files/route.ts
+++ b/src/app/api/manage/files/route.ts
@@ -1,7 +1,7 @@
 // src/app/api/manage/files/route.ts
-// 승인된 이미지 목록 조회 — DEPLOYED_UPLOAD_DIR/img 기준 (읽기 전용, 페이지네이션)
+// 승인된 이미지 목록 조회 — DEPLOYED_UPLOAD_DIR/<IMG_SUBDIR> 기준 (읽기 전용, 페이지네이션)
 
-import fs from 'fs';
+import { readdir, stat } from 'fs/promises';
 import path from 'path';
 
 import { NextRequest } from 'next/server';
@@ -24,8 +24,9 @@ function normalizeBaseUrl(): string {
 
 /**
  * GET /api/manage/files?page=N&path=<상대경로>
- * - path는 img 루트 기준 상대 경로 (빈 문자열 = img 루트 자체)
- * - img 디렉토리 범위 이탈 차단
+ * - path는 이미지 루트 기준 상대 경로 (빈 문자열 = 이미지 루트 자체)
+ * - 이미지 루트 범위 이탈 차단 (path.sep 기준 엄격 비교)
+ * - 디렉토리가 아닌 경로 입력 시 400
  */
 export async function GET(request: NextRequest) {
     try {
@@ -47,44 +48,63 @@ export async function GET(request: NextRequest) {
         const imgRoot = path.join(resolveDeployedRoot(), DEPLOYED_IMG_SUBDIR);
         const absolutePath = path.join(imgRoot, relativePath);
 
-        // 보안: 이미지 루트 범위 이탈 방지
-        if (!absolutePath.startsWith(imgRoot)) {
+        // 보안: 이미지 루트 범위 이탈 방지 — path.sep 기준 엄격 비교
+        // (단순 startsWith 로는 /data/img 가 /data/img_secret 를 허용하는 취약점이 있음)
+        if (absolutePath !== imgRoot && !absolutePath.startsWith(imgRoot + path.sep)) {
             return errorResponse('유효하지 않은 경로입니다.', 400);
         }
 
-        if (!fs.existsSync(absolutePath)) {
-            // 아직 이미지 폴더가 없는 경우(승인된 이미지 0건)에도 빈 목록 반환
-            return successResponse({
-                files: [],
-                hasMore: false,
-                nextPage: null,
-                currentPath: relativePath,
-            });
+        // 존재·디렉토리 여부 확인 (stat 실패 시 404/400 분기)
+        let isDir = false;
+        try {
+            const st = await stat(absolutePath);
+            isDir = st.isDirectory();
+        } catch {
+            // ENOENT — 아직 이미지 폴더가 없는 경우(승인 이미지 0건) 루트면 빈 목록 반환
+            if (absolutePath === imgRoot) {
+                return successResponse({
+                    files: [],
+                    hasMore: false,
+                    nextPage: null,
+                    currentPath: relativePath,
+                });
+            }
+            return errorResponse('디렉토리를 찾을 수 없습니다.', 404);
+        }
+
+        if (!isDir) {
+            return errorResponse('경로가 디렉토리가 아닙니다.', 400);
         }
 
         const baseUrl = normalizeBaseUrl();
 
-        const allFiles = fs
-            .readdirSync(absolutePath)
-            .map((file) => {
-                const filePath = path.join(absolutePath, file);
-                const stats = fs.statSync(filePath);
-                const urlPath = relativePath ? `${relativePath}/${file}` : file;
+        // 비동기 병렬 처리 — withFileTypes 로 stat 호출 최소화
+        const dirents = await readdir(absolutePath, { withFileTypes: true });
+
+        const allFiles = await Promise.all(
+            dirents.map(async (dirent) => {
+                const filePath = path.join(absolutePath, dirent.name);
+                const fileRelPath = relativePath ? `${relativePath}/${dirent.name}` : dirent.name;
+                // 크기·수정시간은 stat 로만 얻을 수 있어 병렬 호출
+                const fileStat = await stat(filePath);
 
                 return {
-                    name: file,
-                    size: stats.size,
-                    isDirectory: stats.isDirectory(),
-                    url: `${baseUrl}${urlPath}`,
-                    modified: stats.mtime.getTime(),
+                    name: dirent.name,
+                    size: fileStat.size,
+                    isDirectory: dirent.isDirectory(),
+                    path: fileRelPath, // ← 클라이언트가 하위 폴더 이동 등에 사용하는 상대 경로
+                    url: `${baseUrl}${fileRelPath}`,
+                    modified: fileStat.mtime.getTime(),
                 };
-            })
-            // 디렉토리 우선, 이후 최신순 정렬
-            .sort((a, b) => {
-                if (a.isDirectory && !b.isDirectory) return -1;
-                if (!a.isDirectory && b.isDirectory) return 1;
-                return b.modified - a.modified;
-            });
+            }),
+        );
+
+        // 디렉토리 우선, 이후 최신순 정렬
+        allFiles.sort((a, b) => {
+            if (a.isDirectory && !b.isDirectory) return -1;
+            if (!a.isDirectory && b.isDirectory) return 1;
+            return b.modified - a.modified;
+        });
 
         const startIndex = (page - 1) * PAGE_SIZE;
         const paginatedFiles = allFiles.slice(startIndex, startIndex + PAGE_SIZE);

--- a/src/app/api/manage/files/route.ts
+++ b/src/app/api/manage/files/route.ts
@@ -1,0 +1,103 @@
+// src/app/api/manage/files/route.ts
+// 승인된 이미지 목록 조회 — DEPLOYED_UPLOAD_DIR/img 기준 (읽기 전용, 페이지네이션)
+
+import fs from 'fs';
+import path from 'path';
+
+import { NextRequest } from 'next/server';
+
+import { DEPLOYED_UPLOAD_DIR, DEPLOYED_BASE_URL, DEPLOYED_IMG_SUBDIR } from '@/lib/env';
+import { successResponse, errorResponse, getErrorMessage } from '@/lib/api-response';
+import { canReadCms, getCurrentUser } from '@/lib/current-user';
+
+const PAGE_SIZE = 24;
+
+/** 절대 경로 해석 */
+function resolveDeployedRoot(): string {
+    return path.isAbsolute(DEPLOYED_UPLOAD_DIR) ? DEPLOYED_UPLOAD_DIR : path.join(process.cwd(), DEPLOYED_UPLOAD_DIR);
+}
+
+/** URL prefix 정규화 — 끝 슬래시 보장 */
+function normalizeBaseUrl(): string {
+    return DEPLOYED_BASE_URL.endsWith('/') ? DEPLOYED_BASE_URL : `${DEPLOYED_BASE_URL}/`;
+}
+
+/**
+ * GET /api/manage/files?page=N&path=<상대경로>
+ * - path는 img 루트 기준 상대 경로 (빈 문자열 = img 루트 자체)
+ * - img 디렉토리 범위 이탈 차단
+ */
+export async function GET(request: NextRequest) {
+    try {
+        const currentUser = await getCurrentUser();
+        if (!canReadCms(currentUser)) {
+            return errorResponse('Permission denied.', 403);
+        }
+
+        const { searchParams } = new URL(request.url);
+        const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10) || 1);
+        const relativePath = searchParams.get('path') || '';
+
+        // 보안: 디렉토리 트래버설 방지
+        if (relativePath.includes('..')) {
+            return errorResponse('유효하지 않은 경로입니다.', 400);
+        }
+
+        // 이미지 루트를 베이스로 고정 (env.DEPLOYED_IMG_SUBDIR)
+        const imgRoot = path.join(resolveDeployedRoot(), DEPLOYED_IMG_SUBDIR);
+        const absolutePath = path.join(imgRoot, relativePath);
+
+        // 보안: 이미지 루트 범위 이탈 방지
+        if (!absolutePath.startsWith(imgRoot)) {
+            return errorResponse('유효하지 않은 경로입니다.', 400);
+        }
+
+        if (!fs.existsSync(absolutePath)) {
+            // 아직 이미지 폴더가 없는 경우(승인된 이미지 0건)에도 빈 목록 반환
+            return successResponse({
+                files: [],
+                hasMore: false,
+                nextPage: null,
+                currentPath: relativePath,
+            });
+        }
+
+        const baseUrl = normalizeBaseUrl();
+
+        const allFiles = fs
+            .readdirSync(absolutePath)
+            .map((file) => {
+                const filePath = path.join(absolutePath, file);
+                const stats = fs.statSync(filePath);
+                const urlPath = relativePath ? `${relativePath}/${file}` : file;
+
+                return {
+                    name: file,
+                    size: stats.size,
+                    isDirectory: stats.isDirectory(),
+                    url: `${baseUrl}${urlPath}`,
+                    modified: stats.mtime.getTime(),
+                };
+            })
+            // 디렉토리 우선, 이후 최신순 정렬
+            .sort((a, b) => {
+                if (a.isDirectory && !b.isDirectory) return -1;
+                if (!a.isDirectory && b.isDirectory) return 1;
+                return b.modified - a.modified;
+            });
+
+        const startIndex = (page - 1) * PAGE_SIZE;
+        const paginatedFiles = allFiles.slice(startIndex, startIndex + PAGE_SIZE);
+        const hasMore = startIndex + PAGE_SIZE < allFiles.length;
+
+        return successResponse({
+            files: paginatedFiles,
+            hasMore,
+            nextPage: hasMore ? page + 1 : null,
+            currentPath: relativePath,
+        });
+    } catch (err: unknown) {
+        console.error('파일 목록 조회 실패:', err);
+        return errorResponse(getErrorMessage(err));
+    }
+}

--- a/src/app/api/manage/folders/route.ts
+++ b/src/app/api/manage/folders/route.ts
@@ -1,7 +1,7 @@
 // src/app/api/manage/folders/route.ts
-// 승인된 이미지 폴더 트리 조회 — DEPLOYED_UPLOAD_DIR/img 기준 (읽기 전용)
+// 승인된 이미지 폴더 트리 조회 — DEPLOYED_UPLOAD_DIR/<IMG_SUBDIR> 기준 (읽기 전용)
 
-import fs from 'fs';
+import { readdir } from 'fs/promises';
 import path from 'path';
 
 import { DEPLOYED_UPLOAD_DIR, DEPLOYED_IMG_SUBDIR } from '@/lib/env';
@@ -15,39 +15,39 @@ interface FolderNode {
     isExpanded?: boolean;
 }
 
-/** 승인 이미지 루트(img 폴더) 하위 디렉토리 재귀 탐색 */
-function buildFolderTree(dirPath: string, relativePath: string = ''): FolderNode[] {
-    if (!fs.existsSync(dirPath)) return [];
-
-    const items = fs.readdirSync(dirPath);
-    const folders: FolderNode[] = [];
-
-    for (const item of items) {
-        const fullPath = path.join(dirPath, item);
-        const stats = fs.statSync(fullPath);
-
-        if (stats.isDirectory()) {
-            const itemRelativePath = relativePath ? `${relativePath}/${item}` : item;
-            const children = buildFolderTree(fullPath, itemRelativePath);
-
-            folders.push({
-                name: item,
-                path: itemRelativePath,
-                children: children.length > 0 ? children : undefined,
-                isExpanded: false,
-            });
-        }
+/** 이미지 루트 하위 디렉토리 재귀 탐색 (비동기 병렬) */
+async function buildFolderTree(dirPath: string, relativePath: string = ''): Promise<FolderNode[]> {
+    let dirents;
+    try {
+        dirents = await readdir(dirPath, { withFileTypes: true });
+    } catch {
+        return []; // 디렉토리 없으면 빈 배열
     }
+
+    const folders = await Promise.all(
+        dirents
+            .filter((d) => d.isDirectory())
+            .map(async (d) => {
+                const itemRelativePath = relativePath ? `${relativePath}/${d.name}` : d.name;
+                const children = await buildFolderTree(path.join(dirPath, d.name), itemRelativePath);
+                return {
+                    name: d.name,
+                    path: itemRelativePath,
+                    children: children.length > 0 ? children : undefined,
+                    isExpanded: false,
+                } satisfies FolderNode;
+            }),
+    );
 
     return folders.sort((a, b) => a.name.localeCompare(b.name));
 }
 
-/** 절대 경로 해석 — DEPLOYED_UPLOAD_DIR가 상대경로면 process.cwd() 기준 */
+/** 절대 경로 해석 */
 function resolveDeployedRoot(): string {
     return path.isAbsolute(DEPLOYED_UPLOAD_DIR) ? DEPLOYED_UPLOAD_DIR : path.join(process.cwd(), DEPLOYED_UPLOAD_DIR);
 }
 
-/** GET /api/manage/folders — 승인 이미지 폴더 트리 (루트 고정: img) */
+/** GET /api/manage/folders — 승인 이미지 폴더 트리 (루트 고정: <DEPLOYED_IMG_SUBDIR>) */
 export async function GET() {
     try {
         const currentUser = await getCurrentUser();
@@ -59,7 +59,7 @@ export async function GET() {
 
         // 루트 이름·경로 모두 env (DEPLOYED_IMG_SUBDIR) 에서 가져옴
         // 하위 디렉토리는 실제 파일시스템 구조 그대로 반영
-        const children = buildFolderTree(imgRoot);
+        const children = await buildFolderTree(imgRoot);
 
         const root: FolderNode = {
             name: DEPLOYED_IMG_SUBDIR,

--- a/src/app/api/manage/folders/route.ts
+++ b/src/app/api/manage/folders/route.ts
@@ -1,0 +1,76 @@
+// src/app/api/manage/folders/route.ts
+// 승인된 이미지 폴더 트리 조회 — DEPLOYED_UPLOAD_DIR/img 기준 (읽기 전용)
+
+import fs from 'fs';
+import path from 'path';
+
+import { DEPLOYED_UPLOAD_DIR, DEPLOYED_IMG_SUBDIR } from '@/lib/env';
+import { successResponse, errorResponse, getErrorMessage } from '@/lib/api-response';
+import { canReadCms, getCurrentUser } from '@/lib/current-user';
+
+interface FolderNode {
+    name: string;
+    path: string;
+    children?: FolderNode[];
+    isExpanded?: boolean;
+}
+
+/** 승인 이미지 루트(img 폴더) 하위 디렉토리 재귀 탐색 */
+function buildFolderTree(dirPath: string, relativePath: string = ''): FolderNode[] {
+    if (!fs.existsSync(dirPath)) return [];
+
+    const items = fs.readdirSync(dirPath);
+    const folders: FolderNode[] = [];
+
+    for (const item of items) {
+        const fullPath = path.join(dirPath, item);
+        const stats = fs.statSync(fullPath);
+
+        if (stats.isDirectory()) {
+            const itemRelativePath = relativePath ? `${relativePath}/${item}` : item;
+            const children = buildFolderTree(fullPath, itemRelativePath);
+
+            folders.push({
+                name: item,
+                path: itemRelativePath,
+                children: children.length > 0 ? children : undefined,
+                isExpanded: false,
+            });
+        }
+    }
+
+    return folders.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** 절대 경로 해석 — DEPLOYED_UPLOAD_DIR가 상대경로면 process.cwd() 기준 */
+function resolveDeployedRoot(): string {
+    return path.isAbsolute(DEPLOYED_UPLOAD_DIR) ? DEPLOYED_UPLOAD_DIR : path.join(process.cwd(), DEPLOYED_UPLOAD_DIR);
+}
+
+/** GET /api/manage/folders — 승인 이미지 폴더 트리 (루트 고정: img) */
+export async function GET() {
+    try {
+        const currentUser = await getCurrentUser();
+        if (!canReadCms(currentUser)) {
+            return errorResponse('Permission denied.', 403);
+        }
+
+        const imgRoot = path.join(resolveDeployedRoot(), DEPLOYED_IMG_SUBDIR);
+
+        // 루트 이름·경로 모두 env (DEPLOYED_IMG_SUBDIR) 에서 가져옴
+        // 하위 디렉토리는 실제 파일시스템 구조 그대로 반영
+        const children = buildFolderTree(imgRoot);
+
+        const root: FolderNode = {
+            name: DEPLOYED_IMG_SUBDIR,
+            path: '', // 빈 경로 = 이미지 루트 자체 (files route에서 path 파라미터로 공백 전달)
+            children: children.length > 0 ? children : undefined,
+            isExpanded: true,
+        };
+
+        return successResponse({ folders: [root] });
+    } catch (err: unknown) {
+        console.error('폴더 트리 조회 실패:', err);
+        return errorResponse(getErrorMessage(err));
+    }
+}

--- a/src/app/files/page.tsx
+++ b/src/app/files/page.tsx
@@ -1,9 +1,25 @@
+// src/app/files/page.tsx
+// 승인 이미지 브라우저 페이지 — 에디터에서 팝업으로 오픈되어 이미지 선택에 사용됨
 import { redirect } from 'next/navigation';
 
-import { adminPath } from '@/lib/cms-admin-boundary';
+import FileBrowser from '@/components/files/FileBrowser';
+import { nextApi } from '@/lib/api-url';
+import { canReadCms, getCurrentUser } from '@/lib/current-user';
 
 export const dynamic = 'force-dynamic';
 
-export default function FilesPage() {
-    redirect(adminPath('/cms-admin/approvals'));
+export default async function FilesPage() {
+    const currentUser = await getCurrentUser();
+    if (!canReadCms(currentUser)) {
+        redirect('/not-authorized');
+    }
+
+    return (
+        <FileBrowser
+            apiEndpoints={{
+                folders: nextApi('/api/manage/folders'),
+                files: nextApi('/api/manage/files'),
+            }}
+        />
+    );
 }

--- a/src/components/edit/EditClient.tsx
+++ b/src/components/edit/EditClient.tsx
@@ -500,7 +500,12 @@ export default function EditClient({
             generateMediaUrl_Fal: nextApi('/api/fal/request'),
             checkRequestStatusUrl_Fal: nextApi('/api/fal/status'),
             getResultUrl_Fal: nextApi('/api/fal/result'),
-            // filePicker 제거 — DB 전환 후 로컬 파일 브라우저 불필요, upload 함수로 이미지 삽입
+            // 이미지 삽입 시 승인된 이미지만 선택하도록 전용 브라우저(/files) 오픈
+            // - filePicker: 스니펫 내부 커스텀 이미지 필드 (예: 퀵뱅킹 링크 선택)
+            // - imageSelect: 에디터 기본 "이미지 변경" 툴바 버튼 (이미지 블록·헤더 이미지 등)
+            filePicker: nextApi('/files'),
+            imageSelect: nextApi('/files'),
+            filePickerSize: 'medium',
 
             // 컬러 피커 색상 팔레트
             colors: CMS_COLORS,
@@ -1913,7 +1918,40 @@ export default function EditClient({
         };
     }, []);
 
-    // Listen for file selection from the file picker (/files)
+    // ── ContentBuilder 기본 "이미지 변경" 버튼 인터셉트 ─────────────
+    // ContentBuilder의 `#fileEmbedImage` (이미지 블록·헤더 이미지 변경) 는
+    // filePicker/imageSelect 옵션을 경유하지 않고 OS 파일 선택창을 직접 띄움.
+    // → 클릭을 캡처 단계에서 가로채서 승인 이미지 브라우저(/files) 팝업으로 우회
+    const imageReplaceTargetRef = useRef<HTMLImageElement | null>(null);
+
+    useEffect(() => {
+        const handleFileInputClick = (e: MouseEvent) => {
+            const target = e.target as HTMLElement;
+            if (!(target instanceof HTMLInputElement)) return;
+            if (target.type !== 'file') return;
+            if (target.id !== 'fileEmbedImage') return;
+
+            e.preventDefault();
+            e.stopImmediatePropagation();
+
+            // 현재 편집 중인 이미지 참조 저장 — postMessage 응답에서 src 교체에 사용
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ContentBuilder 내부 속성
+            const activeImg = (builderRef.current as any)?.activeImage as HTMLImageElement | null;
+            imageReplaceTargetRef.current = activeImg ?? null;
+
+            // 팝업으로 /files 오픈 (postMessage 타겟은 window.opener 경로 사용)
+            window.open(nextApi('/files'), 'spw-image-browser', 'width=1280,height=900,scrollbars=yes,resizable=yes');
+        };
+
+        document.addEventListener('click', handleFileInputClick, true);
+        return () => document.removeEventListener('click', handleFileInputClick, true);
+    }, []);
+
+    // 파일 피커(/files)에서 이미지 선택 시 에디터에 삽입 또는 교체
+    // - ASSET_SELECTED: 단건 삽입 (하위 호환)
+    // - ASSETS_SELECTED: 다건 — 완료 버튼 경유
+    //   · 교체 모드 (imageReplaceTargetRef 가 있을 때): 첫 URL 로 activeImage src 교체
+    //   · 삽입 모드: selectAsset 루프 호출
     useEffect(() => {
         const handleMessage = (event: MessageEvent) => {
             switch (event.data.type) {
@@ -1921,6 +1959,24 @@ export default function EditClient({
                     builderRef.current?.selectAsset(event.data.url);
                     window.focus();
                     break;
+                case 'ASSETS_SELECTED': {
+                    const urls: string[] = Array.isArray(event.data.urls) ? event.data.urls : [];
+                    const replaceTarget = imageReplaceTargetRef.current;
+
+                    if (replaceTarget && urls[0]) {
+                        // 이미지 교체 모드
+                        replaceTarget.setAttribute('src', urls[0]);
+                        imageReplaceTargetRef.current = null;
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ContentBuilder 내부 onChange
+                        const onChange = (builderRef.current as any)?.opts?.onChange;
+                        if (typeof onChange === 'function') onChange();
+                    } else {
+                        // 일반 삽입 모드
+                        urls.forEach((url) => builderRef.current?.selectAsset(url));
+                    }
+                    window.focus();
+                    break;
+                }
                 default:
                     break;
             }

--- a/src/components/files/Breadcrumbs.tsx
+++ b/src/components/files/Breadcrumbs.tsx
@@ -1,0 +1,35 @@
+// src/components/files/Breadcrumbs.tsx
+'use client';
+
+import { ChevronRight } from 'lucide-react';
+
+export interface BreadcrumbsProps {
+    currentPath: string;
+    navigateToBreadcrumb: (index: number) => void;
+    /** 루트 폴더 표시명 (env.DEPLOYED_IMG_SUBDIR 가 folders API 응답에서 주입됨) */
+    rootName: string;
+}
+
+export default function Breadcrumbs({ currentPath, navigateToBreadcrumb, rootName }: BreadcrumbsProps) {
+    // 루트 이름은 폴더 트리 루트 노드와 동일 — 파일시스템 이름 그대로
+    // 하위 폴더가 생기면 '<rootName> > sub1 > sub2' 형태로 누적 표시
+    const getBreadcrumbs = () => (currentPath ? [rootName, ...currentPath.split('/')] : [rootName]);
+
+    return (
+        <div className="flex items-center gap-2 text-sm text-gray-500">
+            {getBreadcrumbs().map((crumb, index) => (
+                <div key={index} className="flex items-center gap-2">
+                    {index > 0 && <ChevronRight className="w-4 h-4" />}
+                    <button
+                        onClick={() => navigateToBreadcrumb(index)}
+                        className={`hover:text-[#0046A4] transition-colors ${
+                            index === getBreadcrumbs().length - 1 ? 'text-[#0046A4] font-medium' : 'cursor-pointer'
+                        }`}
+                    >
+                        {crumb}
+                    </button>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/src/components/files/FileBrowser.tsx
+++ b/src/components/files/FileBrowser.tsx
@@ -1,0 +1,365 @@
+// src/components/files/FileBrowser.tsx
+// 승인된 이미지 선택 전용 브라우저 — 업로드·삭제·폴더 생성 기능 제거
+// 클릭=선택 토글, 완료 버튼을 눌러야 에디터에 전송 (팝업/iframe 양쪽 지원)
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { CheckCircle2, RefreshCw, CheckSquare, Square } from 'lucide-react';
+
+import Sidebar from '@/components/files/Sidebar';
+import FileCard from '@/components/files/FileCard';
+import Breadcrumbs from '@/components/files/Breadcrumbs';
+import type { FileItem } from '@/components/files/types';
+import { nextApi } from '@/lib/api-url';
+
+export type { FileItem } from '@/components/files/types';
+
+interface FolderNode {
+    name: string;
+    path: string;
+    children?: FolderNode[];
+    isExpanded?: boolean;
+}
+
+/** 외부 API 엔드포인트 — 조회용 2개만 유지 (업로드·삭제·폴더생성은 제거됨) */
+export interface ApiEndpoints {
+    folders: string;
+    files: string;
+}
+
+export interface FileBrowserProps {
+    apiEndpoints?: Partial<ApiEndpoints>;
+    className?: string;
+}
+
+const DEFAULT_ENDPOINTS: ApiEndpoints = {
+    folders: nextApi('/api/manage/folders'),
+    files: nextApi('/api/manage/files'),
+};
+
+export default function FileBrowser({ apiEndpoints = {}, className = '' }: FileBrowserProps) {
+    const endpoints = { ...DEFAULT_ENDPOINTS, ...apiEndpoints };
+
+    const [files, setFiles] = useState<FileItem[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [hasMore, setHasMore] = useState(true);
+    const [page, setPage] = useState(1);
+    const [currentPath, setCurrentPath] = useState('');
+    const [folderTree, setFolderTree] = useState<FolderNode[]>([]);
+    const [sidebarOpen, setSidebarOpen] = useState(true);
+    const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set());
+    const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set());
+
+    const loaderRef = useRef<HTMLDivElement>(null);
+    const isFetchingRef = useRef(false);
+
+    // ── 폴더 트리 조회 ──────────────────────────────────────────
+    const fetchFolderTree = useCallback(async () => {
+        try {
+            const res = await fetch(endpoints.folders);
+            if (!res.ok) throw new Error('폴더 목록을 불러오지 못했습니다.');
+            const data = await res.json();
+            setFolderTree(data.folders || []);
+        } catch (err: unknown) {
+            console.error('폴더 트리 로드 실패:', err);
+        }
+    }, [endpoints.folders]);
+
+    // ── 파일 목록 조회 (페이지네이션) ───────────────────────────
+    const fetchFiles = useCallback(
+        async (pageNum: number, path: string) => {
+            if (isFetchingRef.current) return;
+
+            try {
+                isFetchingRef.current = true;
+                const pathParam = path ? `&path=${encodeURIComponent(path)}` : '';
+                const res = await fetch(`${endpoints.files}?page=${pageNum}${pathParam}`);
+                if (!res.ok) throw new Error('파일 목록을 불러오지 못했습니다.');
+                const data = await res.json();
+
+                setFiles((prev) => (pageNum === 1 ? data.files : [...prev, ...data.files]));
+                setHasMore(data.hasMore);
+                setPage(pageNum);
+            } catch (err: unknown) {
+                setError('파일 로드 실패');
+                console.error('파일 로드 오류:', err);
+            } finally {
+                isFetchingRef.current = false;
+                setLoading(false);
+            }
+        },
+        [endpoints.files],
+    );
+
+    // ── 선택 토글 ───────────────────────────────────────────────
+    const toggleFileSelection = (fileUrl: string) => {
+        setSelectedFiles((prev) => {
+            const next = new Set(prev);
+            if (next.has(fileUrl)) next.delete(fileUrl);
+            else next.add(fileUrl);
+            return next;
+        });
+    };
+
+    // 현재 페이지 전체 선택/해제 토글
+    const toggleSelectAll = () => {
+        const imageUrls = files.filter((f) => !f.isDirectory).map((f) => f.url);
+        const allSelected = imageUrls.every((url) => selectedFiles.has(url));
+
+        setSelectedFiles((prev) => {
+            const next = new Set(prev);
+            if (allSelected) {
+                imageUrls.forEach((url) => next.delete(url));
+            } else {
+                imageUrls.forEach((url) => next.add(url));
+            }
+            return next;
+        });
+    };
+
+    // ── 파일 카드 클릭 — 선택 토글만 수행 (팝업 자동 닫기 없음) ──
+    const handleFileClick = (file: FileItem, e: React.MouseEvent) => {
+        e.preventDefault();
+        if (file.isDirectory) {
+            // 승인 이미지 루트(DEPLOYED_BASE_URL) 기준 상대 경로 추출
+            // 예: /deployed/static/sub → sub
+            setCurrentPath(file.url.replace(/^.*?\/([^/]+(?:\/[^/]+)*)$/, (_, rel) => rel));
+            return;
+        }
+        toggleFileSelection(file.url);
+    };
+
+    // ── 완료 — 선택한 이미지 URL 들을 에디터로 전송 ─────────────
+    const handleConfirm = () => {
+        const urls = Array.from(selectedFiles);
+        if (urls.length === 0) return;
+
+        const msg = { type: 'ASSETS_SELECTED', urls };
+
+        // 팝업으로 열렸으면 opener, iframe이면 parent 로 전송
+        if (window.opener) {
+            window.opener.postMessage(msg, '*');
+            window.close();
+        } else if (window.parent && window.parent !== window) {
+            window.parent.postMessage(msg, '*');
+        } else {
+            // 정상 케이스는 아님 — 단독 창 접근 시 콘솔 경고만
+            console.warn('부모 창을 찾지 못해 이미지를 전송할 수 없습니다.', msg);
+        }
+    };
+
+    // 브레드크럼 경로 이동
+    const navigateToBreadcrumb = (index: number) => {
+        if (index === 0) {
+            setCurrentPath('');
+            return;
+        }
+        const pathParts = currentPath.split('/');
+        setCurrentPath(pathParts.slice(0, index).join('/'));
+    };
+
+    const handleRefresh = async () => {
+        setLoading(true);
+        setFiles([]);
+        setPage(1);
+        setHasMore(true);
+        isFetchingRef.current = false;
+        await fetchFiles(1, currentPath);
+        await fetchFolderTree();
+    };
+
+    // 폴더 트리 최초 로드
+    useEffect(() => {
+        fetchFolderTree();
+    }, [fetchFolderTree]);
+
+    // 경로 변경 시 파일 리로드 (선택 상태는 유지 — 폴더 이동해도 선택은 누적)
+    useEffect(() => {
+        setLoading(true);
+        setFiles([]);
+        setPage(1);
+        setHasMore(true);
+        isFetchingRef.current = false;
+        fetchFiles(1, currentPath);
+    }, [currentPath, fetchFiles]);
+
+    // 무한 스크롤
+    useEffect(() => {
+        const currentLoader = loaderRef.current;
+        if (!currentLoader || !hasMore || loading) return;
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (entries[0].isIntersecting && !isFetchingRef.current) {
+                    fetchFiles(page + 1, currentPath);
+                }
+            },
+            { threshold: 0.1 },
+        );
+
+        observer.observe(currentLoader);
+
+        return () => {
+            if (currentLoader) {
+                observer.unobserve(currentLoader);
+            }
+        };
+    }, [page, hasMore, loading, currentPath, fetchFiles]);
+
+    // 현재 페이지의 (디렉토리 제외) 이미지가 모두 선택되었는지
+    const currentImageUrls = files.filter((f) => !f.isDirectory).map((f) => f.url);
+    const allSelected = currentImageUrls.length > 0 && currentImageUrls.every((url) => selectedFiles.has(url));
+
+    if (loading && page === 1) {
+        return (
+            <div className="min-h-screen flex items-center justify-center">
+                <div className="text-gray-500">이미지 불러오는 중...</div>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="min-h-screen flex items-center justify-center">
+                <div className="text-red-500">{error}</div>
+            </div>
+        );
+    }
+
+    return (
+        <div className={`h-screen bg-gray-50 flex ${className}`}>
+            {/* 사이드바 — 폴더 트리 */}
+            <div
+                className={`h-full w-64 bg-white shadow transform transition-transform duration-300 ease-in-out ${
+                    sidebarOpen ? 'translate-x-0' : '-translate-x-full'
+                }`}
+            >
+                <Sidebar
+                    folderTree={folderTree}
+                    currentPath={currentPath}
+                    onFolderClick={setCurrentPath}
+                    expandedFolders={expandedFolders}
+                    onToggleFolder={(path) => {
+                        setExpandedFolders((prev) => {
+                            const newSet = new Set(prev);
+                            if (newSet.has(path)) newSet.delete(path);
+                            else newSet.add(path);
+                            return newSet;
+                        });
+                    }}
+                />
+            </div>
+
+            {/* 메인 영역 */}
+            <div
+                className="flex flex-col flex-1 transition-all duration-300"
+                style={{ marginLeft: sidebarOpen ? 0 : -256 }}
+            >
+                {/* 상단 헤더 — 브레드크럼 + 액션 버튼 */}
+                <div className="shrink-0 pt-4 pb-2 px-4 md:pt-8 md:pb-4 md:px-8">
+                    <div className="flex items-center justify-between mb-6">
+                        <div className="flex items-center gap-4">
+                            <Breadcrumbs
+                                currentPath={currentPath}
+                                navigateToBreadcrumb={navigateToBreadcrumb}
+                                rootName={folderTree[0]?.name ?? ''}
+                            />
+                            {selectedFiles.size > 0 && (
+                                <span className="text-sm font-medium text-[#0046A4] bg-[#EBF4FF] px-3 py-1 rounded-full">
+                                    {selectedFiles.size}개 선택됨
+                                </span>
+                            )}
+                        </div>
+
+                        <div className="flex items-center gap-2">
+                            {/* Refresh */}
+                            <button
+                                onClick={handleRefresh}
+                                className="flex items-center gap-2 px-4 py-2 bg-[#F0F4FF] text-[#0046A4] border border-[#C7D8F4] rounded-lg hover:bg-[#EBF4FF] hover:border-[#0046A4] transition-colors cursor-pointer"
+                                title="새로고침"
+                            >
+                                <RefreshCw className="w-4 h-4" />
+                                <span className="text-sm">새로고침</span>
+                            </button>
+
+                            {/* 전체 선택 토글 */}
+                            {currentImageUrls.length > 0 && (
+                                <button
+                                    onClick={toggleSelectAll}
+                                    className="flex items-center gap-2 px-4 py-2 bg-[#F0F4FF] text-[#0046A4] border border-[#C7D8F4] rounded-lg hover:bg-[#EBF4FF] hover:border-[#0046A4] transition-colors cursor-pointer"
+                                >
+                                    {allSelected ? <CheckSquare className="w-4 h-4" /> : <Square className="w-4 h-4" />}
+                                    <span className="text-sm">{allSelected ? '전체 해제' : '전체 선택'}</span>
+                                </button>
+                            )}
+
+                            {/* 완료 */}
+                            <button
+                                onClick={handleConfirm}
+                                disabled={selectedFiles.size === 0}
+                                className="flex items-center gap-2 px-4 py-2 bg-[#0046A4] text-white rounded-lg hover:bg-[#003399] transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+                            >
+                                <CheckCircle2 className="w-4 h-4" />
+                                <span className="text-sm">완료</span>
+                            </button>
+
+                            {/* 사이드바 토글 햄버거 */}
+                            <button
+                                onClick={() => setSidebarOpen(!sidebarOpen)}
+                                className="text-gray-600 hover:text-gray-900 p-2 cursor-pointer"
+                                title="사이드바 토글"
+                            >
+                                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={2}
+                                        d="M4 6h16M4 12h16M4 18h16"
+                                    />
+                                </svg>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                {/* 파일 그리드 (스크롤) */}
+                <div className="flex-1 overflow-y-auto p-4 md:p-8">
+                    {files.length === 0 ? (
+                        <div className="text-center py-12 text-gray-500 border-2 border-dashed border-gray-300 rounded-lg">
+                            <p className="font-medium">승인된 이미지가 없습니다.</p>
+                            <p className="text-sm mt-1">Spider Admin에서 이미지를 승인한 뒤 다시 시도해주세요.</p>
+                        </div>
+                    ) : (
+                        <>
+                            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-7 gap-4">
+                                {files.map((file, index) => (
+                                    <FileCard
+                                        key={`${file.url}-${index}`}
+                                        file={file}
+                                        isSelected={selectedFiles.has(file.url)}
+                                        selectionMode={true}
+                                        onClick={handleFileClick}
+                                        priority={index < 5}
+                                    />
+                                ))}
+                            </div>
+
+                            {hasMore && (
+                                <div ref={loaderRef} className="flex justify-center py-8">
+                                    <div className="text-gray-500 text-sm">더 불러오는 중...</div>
+                                </div>
+                            )}
+
+                            {!hasMore && files.length > 0 && (
+                                <div className="flex justify-center py-8 text-gray-400 text-sm">
+                                    모든 이미지를 불러왔습니다.
+                                </div>
+                            )}
+                        </>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/files/FileBrowser.tsx
+++ b/src/components/files/FileBrowser.tsx
@@ -122,9 +122,8 @@ export default function FileBrowser({ apiEndpoints = {}, className = '' }: FileB
     const handleFileClick = (file: FileItem, e: React.MouseEvent) => {
         e.preventDefault();
         if (file.isDirectory) {
-            // 승인 이미지 루트(DEPLOYED_BASE_URL) 기준 상대 경로 추출
-            // 예: /deployed/static/sub → sub
-            setCurrentPath(file.url.replace(/^.*?\/([^/]+(?:\/[^/]+)*)$/, (_, rel) => rel));
+            // 서버 응답의 상대 경로 사용 — URL 파싱 불필요
+            setCurrentPath(file.path);
             return;
         }
         toggleFileSelection(file.url);

--- a/src/components/files/FileCard.tsx
+++ b/src/components/files/FileCard.tsx
@@ -1,0 +1,131 @@
+// src/components/files/FileCard.tsx
+'use client';
+
+import Image from 'next/image';
+import { Check, Folder } from 'lucide-react';
+import type { FileItem } from '@/components/files/types';
+
+export interface FileCardProps {
+    file: FileItem;
+    isSelected: boolean;
+    selectionMode: boolean;
+    onClick: (file: FileItem, e: React.MouseEvent) => void;
+    priority?: boolean;
+}
+
+export default function FileCard({ file, isSelected, selectionMode, onClick, priority }: FileCardProps) {
+    const getFileIcon = (fileName: string) => {
+        const ext = fileName.split('.').pop()?.toLowerCase() || '';
+        const iconClass = 'w-16 h-16 text-gray-400';
+
+        if (['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg'].includes(ext)) {
+            return null;
+        }
+
+        if (['mp4', 'mov', 'avi', 'webm'].includes(ext)) {
+            return (
+                <svg className={iconClass} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={1.2}
+                        d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"
+                    />
+                </svg>
+            );
+        }
+
+        if (['zip', 'rar', '7z', 'tar', 'gz'].includes(ext)) {
+            return (
+                <svg className={iconClass} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={1.2}
+                        d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                    />
+                </svg>
+            );
+        }
+
+        if (['pdf'].includes(ext)) {
+            return (
+                <svg className={iconClass} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={1.2}
+                        d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                    />
+                </svg>
+            );
+        }
+
+        return (
+            <svg className={iconClass} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1.2}
+                    d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                />
+            </svg>
+        );
+    };
+
+    const handleImageError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
+        const target = e.target as HTMLImageElement;
+        target.style.display = 'none';
+        const parent = target.parentElement;
+        if (parent) {
+            parent.innerHTML =
+                '<div class="w-full h-full flex items-center justify-center"><svg class="w-16 h-16 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg></div>';
+        }
+    };
+
+    return (
+        <div
+            onClick={(e) => onClick(file, e)}
+            className={`group cursor-pointer rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-all duration-200 relative ${
+                isSelected ? 'ring-2 ring-[#0046A4] bg-[#EBF4FF]' : 'bg-white'
+            }`}
+        >
+            {/* 선택 체크 배지 — 디렉토리 제외, 선택 모드 ON 시 표시 */}
+            {selectionMode && !file.isDirectory && (
+                <div className="absolute top-2 left-2 z-10">
+                    <div
+                        className={`w-6 h-6 rounded-md border-2 flex items-center justify-center shadow ${
+                            isSelected ? 'bg-[#0046A4] border-[#0046A4]' : 'bg-white border-gray-300'
+                        }`}
+                    >
+                        {isSelected && <Check className="w-4 h-4 text-white" strokeWidth={3} />}
+                    </div>
+                </div>
+            )}
+
+            <div className="aspect-square flex items-center justify-center bg-gray-100 relative">
+                {file.isDirectory ? (
+                    <Folder className="w-16 h-16 text-black-300" strokeWidth={1} />
+                ) : (
+                    getFileIcon(file.name) || (
+                        <Image
+                            src={file.url}
+                            alt={file.name}
+                            width={300}
+                            height={300}
+                            className="w-full h-full object-cover"
+                            onError={handleImageError}
+                            unoptimized={file.url.endsWith('.svg')}
+                            priority={priority}
+                        />
+                    )
+                )}
+            </div>
+            <div className="p-2">
+                <p className="text-xs text-gray-600 truncate group-hover:text-gray-900 transition-colors">
+                    {file.name}
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/src/components/files/FolderTree.tsx
+++ b/src/components/files/FolderTree.tsx
@@ -1,0 +1,91 @@
+// src/components/files/FolderTree.tsx
+
+import { ChevronDown, ChevronRight, Folder, FolderOpen } from 'lucide-react';
+
+interface FolderNode {
+    name: string;
+    path: string;
+    children?: FolderNode[];
+}
+
+interface FolderTreeProps {
+    nodes: FolderNode[];
+    currentPath: string;
+    onFolderClick: (path: string) => void;
+    expandedFolders: Set<string>;
+    onToggleFolder: (path: string) => void;
+    level?: number;
+}
+
+export default function FolderTree({
+    nodes,
+    currentPath,
+    onFolderClick,
+    expandedFolders,
+    onToggleFolder,
+    level = 0,
+}: FolderTreeProps) {
+    return (
+        <>
+            {nodes.map((node) => {
+                const isExpanded = expandedFolders.has(node.path);
+                const isActive = currentPath === node.path;
+
+                return (
+                    <div key={node.path}>
+                        <div
+                            className={`flex items-center gap-2 px-3 py-1.5 rounded-md cursor-pointer transition-colors ${
+                                isActive
+                                    ? 'bg-[#EBF4FF] text-[#0046A4] font-medium'
+                                    : 'hover:bg-[#EBF4FF] hover:text-[#0046A4] text-gray-700'
+                            }`}
+                            style={{ paddingLeft: `${level * 12 + 12}px` }}
+                        >
+                            {node.children?.length ? (
+                                <button
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        onToggleFolder(node.path);
+                                    }}
+                                    className="p-0.5 hover:bg-[#C7D8F4] rounded flex-shrink-0 cursor-pointer"
+                                >
+                                    {isExpanded ? (
+                                        <ChevronDown className="w-4 h-4" />
+                                    ) : (
+                                        <ChevronRight className="w-4 h-4" />
+                                    )}
+                                </button>
+                            ) : (
+                                // 하위 폴더 없을 땐 클릭 불가능한 placeholder (hover 음영 없음)
+                                <div className="p-0.5 flex-shrink-0">
+                                    <div className="w-4 h-4" />
+                                </div>
+                            )}
+                            <div
+                                onClick={() => onFolderClick(node.path)}
+                                className="flex items-center gap-2 flex-1 min-w-0"
+                            >
+                                {isExpanded ? (
+                                    <FolderOpen className="w-4 h-4 flex-shrink-0" />
+                                ) : (
+                                    <Folder className="w-4 h-4 flex-shrink-0" />
+                                )}
+                                <span className="text-sm truncate">{node.name}</span>
+                            </div>
+                        </div>
+                        {isExpanded && node.children && (
+                            <FolderTree
+                                nodes={node.children}
+                                currentPath={currentPath}
+                                onFolderClick={onFolderClick}
+                                expandedFolders={expandedFolders}
+                                onToggleFolder={onToggleFolder}
+                                level={level + 1}
+                            />
+                        )}
+                    </div>
+                );
+            })}
+        </>
+    );
+}

--- a/src/components/files/Sidebar.tsx
+++ b/src/components/files/Sidebar.tsx
@@ -1,0 +1,46 @@
+// src/components/files/Sidebar.tsx
+
+'use client';
+
+import FolderTree from './FolderTree';
+
+interface FolderNode {
+    name: string;
+    path: string;
+    children?: FolderNode[];
+    isExpanded?: boolean;
+}
+
+interface SidebarProps {
+    folderTree: FolderNode[];
+    currentPath: string;
+    onFolderClick: (path: string) => void;
+    expandedFolders: Set<string>;
+    onToggleFolder: (path: string) => void;
+}
+
+export default function Sidebar({
+    folderTree,
+    currentPath,
+    onFolderClick,
+    expandedFolders,
+    onToggleFolder,
+}: SidebarProps) {
+    return (
+        <div className="w-64 bg-white border-r border-gray-200 flex-shrink-0">
+            <div className="p-4 border-b border-gray-200">
+                <h2 className="text-sm font-medium text-gray-900">Folders</h2>
+            </div>
+            <div className="p-2 overflow-y-auto h-[calc(100vh-60px)]">
+                {/* 루트 노드 'Img' 는 folders API 에서 반환되어 FolderTree 가 렌더링함 */}
+                <FolderTree
+                    nodes={folderTree}
+                    currentPath={currentPath}
+                    onFolderClick={onFolderClick}
+                    expandedFolders={expandedFolders}
+                    onToggleFolder={onToggleFolder}
+                />
+            </div>
+        </div>
+    );
+}

--- a/src/components/files/types.ts
+++ b/src/components/files/types.ts
@@ -3,6 +3,8 @@
 export interface FileItem {
     name: string;
     url: string;
+    /** 이미지 루트 기준 상대 경로 — 하위 폴더 이동 시 사용 (정규식 파싱 불필요) */
+    path: string;
     isDirectory: boolean;
     size: number;
 }

--- a/src/components/files/types.ts
+++ b/src/components/files/types.ts
@@ -1,0 +1,8 @@
+// src/components/files/types.ts
+
+export interface FileItem {
+    name: string;
+    url: string;
+    isDirectory: boolean;
+    size: number;
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -39,6 +39,13 @@ export const ASSET_BASE_URL = optionalEnv('ASSET_BASE_URL', '/uploads');
 // ── 배포 저장소 (승인 완료 이미지) ──
 export const DEPLOYED_UPLOAD_DIR = optionalEnv('DEPLOYED_UPLOAD_DIR', 'public/deployed');
 export const DEPLOYED_BASE_URL = optionalEnv('DEPLOYED_BASE_URL', '/deployed/static');
+/**
+ * 승인 완료 이미지가 저장되는 서브 디렉토리명 (DEPLOYED_UPLOAD_DIR 아래)
+ * - 승인 시 파일 복사 대상 경로 + 에디터 이미지 브라우저 루트로 사용됨
+ * - 기본값 'img' (운영 /data/deployed/img, 로컬 public/deployed/img)
+ * - 변경 시 Spider Admin·nginx 설정도 함께 맞춰야 함
+ */
+export const DEPLOYED_IMG_SUBDIR = optionalEnv('DEPLOYED_IMG_SUBDIR', 'img');
 
 // ── 브랜드 테마 ──
 export const BANK_BRAND = optionalEnv('BANK_BRAND', '');


### PR DESCRIPTION
closes #33

## Summary
- Phase 7 정리 때 삭제된 `/cms/files` FileBrowser 를 복구하여 **승인 이미지 선택 전용 팝업 브라우저** 로 개조
- 에디터의 이미지 선택 플로 일부를 이 브라우저로 우회 (filePicker + imageSelect + #fileEmbedImage 인터셉트)
- 승인 이미지 서브디렉토리명을 환경변수(`DEPLOYED_IMG_SUBDIR`) 로 추출하여 3개 route 공통 사용
- .env 예시 동기화 (누락 변수 8개 추가 + 미사용 `JWT_SECRET` 제거)

## 변경 파일
### 신규
- `src/app/files/page.tsx` — 승인 이미지 브라우저 엔트리
- `src/components/files/` — FileBrowser, Sidebar, FolderTree, FileCard, Breadcrumbs, types
- `src/app/api/manage/folders/route.ts` — DEPLOYED_UPLOAD_DIR/<IMG_SUBDIR> 기반 폴더 트리
- `src/app/api/manage/files/route.ts` — 위 기반 파일 목록 조회 (페이지네이션)

### 수정
- `src/components/edit/EditClient.tsx` — filePicker/imageSelect 옵션 + ASSETS_SELECTED 핸들러 + #fileEmbedImage 인터셉트
- `src/app/api/assets/[assetId]/deploy/route.ts` — 승인 파일 복사 시 env 서브디렉토리명 사용
- `src/lib/env.ts` — `DEPLOYED_IMG_SUBDIR` export 추가
- `.env.example`·`.env.prod.example` — 동기화

## API 공개 스펙
### 브라우저 동작 (팝업)
- `GET /cms/files` 진입 → 사이드바 + 이미지 그리드 + 전체 선택/완료 버튼
- 이미지 클릭 → ✓ 배지 + 하이라이트 (팝업 유지)
- 완료 → `postMessage({ type: 'ASSETS_SELECTED', urls: string[] })` + 팝업 닫기

### 에디터 수신
- 교체 모드(`#fileEmbedImage` 인터셉트 이후): 첫 URL 로 `activeImage.src` 교체
- 삽입 모드(일반): `urls.forEach(url => builder.selectAsset(url))`

## 운영 .env.prod 수정 필요 항목
아래 두 줄만 추가하면 배포 후 동작 (서브디렉토리 기본 `img` 이라 생략 OK):
\`\`\`
DEPLOYED_UPLOAD_DIR=/app/public/deployed
DEPLOYED_BASE_URL=/deployed/static
\`\`\`
또한 사용되지 않는 `JWT_SECRET` 라인은 제거 권장.

## 미해결 / 후속
- 빈 캔버스 → 이미지 블록 최초 삽입(`#fileInsertImage`) 은 ContentBuilder 내장 모달 구조상 이번 범위에서 제외
- 업로드 경로 전면 차단은 별도 이슈 #32 에서 정책 결정 후 착수

## Test plan
- [ ] 로컬 `/cms/files` 직접 접근 — 사이드바 `img` 루트 1개, 하위 없으면 음영 없음
- [ ] 이미지 카드 클릭 → ✓ + 하이라이트, 팝업 유지
- [ ] 전체 선택 / 해제 토글
- [ ] 완료 → 팝업 닫힘 + 에디터 삽입
- [ ] 퀵뱅킹 메뉴 → 링크 선택 → 승인 브라우저 오픈 (filePicker 경로)
- [ ] 헤더 이미지 → 이미지 변경 → 승인 브라우저 오픈 (#fileEmbedImage 인터셉트)
- [ ] 선택 후 교체 동작 확인 + 저장 시 HTML 반영
- [ ] :3001 서버에서도 동일 UI 뜨고 승인 이미지만 보임