### PR TITLE
파일 브라우저 미리보기 운영 환경 깨짐 수정, 배포

### DIFF
--- a/src/components/files/FileCard.tsx
+++ b/src/components/files/FileCard.tsx
@@ -115,7 +115,11 @@ export default function FileCard({ file, isSelected, selectionMode, onClick, pri
                             height={300}
                             className="w-full h-full object-cover"
                             onError={handleImageError}
-                            unoptimized={file.url.endsWith('.svg')}
+                            // 승인 이미지는 nginx 가 직접 서빙(운영) 또는 public 정적 서빙(로컬).
+                            // Next.js 최적화 endpoint(/_next/image)가 컨테이너 내부에서 파일을
+                            // 다시 fetch 할 때 운영 nginx 리라이트 경로를 통과하지 못해
+                            // 미리보기가 깨짐 → unoptimized 로 브라우저가 원본 URL 을 직접 로드하게 함
+                            unoptimized
                             priority={priority}
                         />
                     )


### PR DESCRIPTION
승인 이미지 카드가 next/image 를 통해 렌더링되면서 Next.js 최적화 엔드포인트 (/cms/_next/image) 가 컨테이너 내부에서 원본 파일을 다시 fetch 하는데, 운영 nginx 의 /deployed/static/ → /data/deployed/img/ 리라이트 경로가 컨테이너 외부에만 존재해 최적화 fetch 가 실패 → 미리보기 깨짐.

승인 이미지는 nginx(운영) 또는 public 정적(로컬) 이 이미 직접 서빙하므로
Next.js 최적화가 불필요. unoptimized 속성으로 브라우저가 원본 URL 을
직접 로드하도록 하여 두 환경 모두 정상 렌더.

## 🔗 관련 이슈 (Related Issues)
> 연결된 이슈 번호를 적어주세요. (예: - #123)

## ✨ 변경 사항 (Changes)
> 무엇이 바뀌었는지 핵심 내용을 설명해 주세요.

## 📸 변경 사항 확인 (선택)
> UI 변경이 있거나 결과물을 시각적으로 보여줄 수 있다면 첨부해 주세요.

| 변경 전 (Before) | 변경 후 (After) |
| :--- | :--- |
| (이미지/GIF) | (이미지/GIF) |

## ⚠️ 고려 및 주의 사항 (선택)
> 배포 시 유의점이나 기술적 부채, 향후 영향도를 적어주세요.

## 💬 리뷰 포인트 (선택)
> 특별히 신경 써서 봐주었으면 하는 부분이나 의견이 필요한 곳을 적어주세요.

## 🔗 참고 사항 (선택)
> 참고 자료 혹은 추가로 전달할 사항을 적어주세요.
