### PR TITLE
[FEATURE #31]: CMS관련 정책 관련 기존 ADMIN에 일치하도록 수정

### DIFF
--- a/e2e/pages/cms-role-policy.spec.ts
+++ b/e2e/pages/cms-role-policy.spec.ts
@@ -11,7 +11,7 @@ test.describe('CMS role policy', () => {
         await expect(page.getByRole('button', { name: '+ 새 페이지' })).toBeVisible();
     });
 
-    test('CMS:W bypass user is blocked from /dashboard', async ({ page, context, baseURL }) => {
+    test('CMS:W bypass user with CMS:R can access /dashboard', async ({ page, context, baseURL }) => {
         await context.addCookies([
             {
                 name: 'cms_bypass_role',
@@ -22,8 +22,8 @@ test.describe('CMS role policy', () => {
 
         await page.goto('/dashboard');
 
-        await expect(page).toHaveURL(/\/not-authorized$/);
-        await expect(page.getByRole('heading', { name: 'CMS access is not allowed.' })).toBeVisible();
+        await expect(page).toHaveURL(/\/dashboard$/);
+        await expect(page.getByRole('heading', { name: '대시보드' })).toBeVisible();
     });
 
     test('CMS:W bypass user is redirected from /approve to /cms-admin/approvals', async ({ page, context, baseURL }) => {

--- a/e2e/pages/cms-role-policy.spec.ts
+++ b/e2e/pages/cms-role-policy.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('CMS role policy', () => {
+    test('CMS:R bypass user can access /dashboard', async ({ page, context }) => {
+        await context.clearCookies();
+
+        await page.goto('/dashboard');
+
+        await expect(page).toHaveURL(/\/dashboard$/);
+        await expect(page.getByRole('heading', { name: '대시보드' })).toBeVisible();
+        await expect(page.getByRole('button', { name: '+ 새 페이지' })).toBeVisible();
+    });
+
+    test('CMS:W bypass user is blocked from /dashboard', async ({ page, context, baseURL }) => {
+        await context.addCookies([
+            {
+                name: 'cms_bypass_role',
+                value: 'cms_admin',
+                url: baseURL!,
+            },
+        ]);
+
+        await page.goto('/dashboard');
+
+        await expect(page).toHaveURL(/\/not-authorized$/);
+        await expect(page.getByRole('heading', { name: 'CMS access is not allowed.' })).toBeVisible();
+    });
+
+    test('CMS:W bypass user is redirected from /approve to /cms-admin/approvals', async ({ page, context, baseURL }) => {
+        await context.addCookies([
+            {
+                name: 'cms_bypass_role',
+                value: 'cms_admin',
+                url: baseURL!,
+            },
+        ]);
+
+        await page.goto('/approve');
+
+        await expect(page).toHaveURL(/\/cms-admin\/approvals$/);
+    });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -62,6 +62,7 @@ export default defineConfig({
     webServer: {
         command: 'npm run dev -- -p 3100',
         env: {
+            AUTH_BYPASS: 'true',
             NEXT_PUBLIC_CMS_BASE_PATH: '',
         },
         url: 'http://localhost:3100',

--- a/src/app/api/builder/load/route.ts
+++ b/src/app/api/builder/load/route.ts
@@ -6,7 +6,7 @@ import { getPageById } from '@/db/repository/page.repository';
 import { isValidBankId } from '@/lib/validators';
 import { readPageHtml } from '@/lib/page-file';
 import { contentBuilderErrorResponse, getErrorMessage } from '@/lib/api-response';
-import { canReadCms, getCurrentUser } from '@/lib/current-user';
+import { canAccessCmsEdit, canManageCmsPage, getCurrentUser } from '@/lib/current-user';
 
 function durationMs(start: number) {
     return Math.round((performance.now() - start) * 10) / 10;
@@ -19,6 +19,7 @@ async function loadPage(bank: string): Promise<{
     fileNotFound?: boolean;
     pageName?: string;
     viewMode?: string;
+    createUserId?: string | null;
     timing: {
         dbMs: number;
         fileMs: number;
@@ -28,7 +29,7 @@ async function loadPage(bank: string): Promise<{
     const page = await getPageById(bank);
     const dbMs = durationMs(dbStart);
     if (!page) {
-        return { html: '', updated: null, timing: { dbMs, fileMs: 0 } };
+        return { html: '', updated: null, createUserId: null, timing: { dbMs, fileMs: 0 } };
     }
 
     let html = '';
@@ -61,6 +62,7 @@ async function loadPage(bank: string): Promise<{
         fileNotFound,
         pageName: page.PAGE_NAME,
         viewMode: page.VIEW_MODE ?? 'mobile',
+        createUserId: page.CREATE_USER_ID ?? null,
         timing: { dbMs, fileMs },
     };
 }
@@ -71,7 +73,7 @@ export async function POST(req: NextRequest) {
         const authStart = performance.now();
         const currentUser = await getCurrentUser();
         const authMs = durationMs(authStart);
-        if (!canReadCms(currentUser)) {
+        if (!canAccessCmsEdit(currentUser)) {
             return contentBuilderErrorResponse('Permission denied.');
         }
 
@@ -81,9 +83,13 @@ export async function POST(req: NextRequest) {
         const parseMs = durationMs(parseStart);
 
         const loadStart = performance.now();
-        const { html, updated, fileNotFound, pageName, viewMode, timing } = await loadPage(bank);
+        const { html, updated, fileNotFound, pageName, viewMode, createUserId, timing } = await loadPage(bank);
         const loadMs = durationMs(loadStart);
         const totalMs = durationMs(totalStart);
+
+        if (createUserId && !canManageCmsPage(currentUser, createUserId)) {
+            return contentBuilderErrorResponse('Permission denied.');
+        }
 
         return NextResponse.json(
             {

--- a/src/app/api/builder/pages/[pageId]/approve-request/route.ts
+++ b/src/app/api/builder/pages/[pageId]/approve-request/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest } from 'next/server';
 
-import { requestApproval } from '@/db/repository/page.repository';
+import { getPageById, requestApproval } from '@/db/repository/page.repository';
 import { errorResponse, getErrorMessage, successResponse } from '@/lib/api-response';
-import { canWriteCms, getCurrentUser } from '@/lib/current-user';
+import { canAccessCmsEdit, canManageCmsPage, getCurrentUser } from '@/lib/current-user';
 
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ pageId: string }> }) {
     try {
@@ -40,7 +40,15 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ pa
         }
 
         const currentUser = await getCurrentUser();
-        if (!canWriteCms(currentUser)) {
+        if (!canAccessCmsEdit(currentUser)) {
+            return errorResponse('Permission denied.', 403);
+        }
+
+        const page = await getPageById(pageId);
+        if (!page) {
+            return errorResponse('Page not found.', 404);
+        }
+        if (!canManageCmsPage(currentUser, page.CREATE_USER_ID)) {
             return errorResponse('Permission denied.', 403);
         }
 

--- a/src/app/api/builder/pages/route.ts
+++ b/src/app/api/builder/pages/route.ts
@@ -4,7 +4,7 @@
 import { NextRequest } from 'next/server';
 
 import { getPageList, getPageById, deletePage } from '@/db/repository/page.repository';
-import { canReadCms, canWriteCms, getCurrentUser } from '@/lib/current-user';
+import { canReadCms, canManageAllCmsPages, canManageCmsPage, getCurrentUser } from '@/lib/current-user';
 import { successResponse, errorResponse, getErrorMessage } from '@/lib/api-response';
 
 /**
@@ -18,6 +18,11 @@ import { successResponse, errorResponse, getErrorMessage } from '@/lib/api-respo
  */
 export async function GET(req: NextRequest) {
     try {
+        const currentUser = await getCurrentUser();
+        if (!canReadCms(currentUser)) {
+            return errorResponse('권한이 없습니다.', 403);
+        }
+
         const { searchParams } = req.nextUrl;
 
         const page = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10));
@@ -26,7 +31,13 @@ export async function GET(req: NextRequest) {
         const sortByParam = searchParams.get('sortBy');
         const sortBy = sortByParam === 'name' ? 'name' : 'date';
 
-        const { list, totalCount } = await getPageList({ page, pageSize, search, sortBy });
+        const { list, totalCount } = await getPageList({
+            page,
+            pageSize,
+            search,
+            sortBy,
+            createUserId: canManageAllCmsPages(currentUser) ? undefined : currentUser.userId,
+        });
 
         const pages = list.map((p) => ({
             id: p.PAGE_ID,
@@ -37,11 +48,6 @@ export async function GET(req: NextRequest) {
             approveState: p.APPROVE_STATE,
             rejectedReason: p.REJECTED_REASON ?? null,
         }));
-
-        const currentUser = await getCurrentUser();
-        if (!canReadCms(currentUser)) {
-            return errorResponse('권한이 없습니다.', 403);
-        }
         const { userId } = currentUser;
         return successResponse({ pages, totalCount, currentUserId: userId });
     } catch (err: unknown) {
@@ -69,7 +75,7 @@ export async function DELETE(req: NextRequest) {
         }
 
         const currentUser = await getCurrentUser();
-        if (!canWriteCms(currentUser)) {
+        if (!canManageCmsPage(currentUser, page.CREATE_USER_ID)) {
             return errorResponse('권한이 없습니다.', 403);
         }
         const { userId } = currentUser;

--- a/src/app/api/builder/save/route.ts
+++ b/src/app/api/builder/save/route.ts
@@ -3,7 +3,7 @@
 import { NextRequest } from 'next/server';
 
 import { updatePage, createPage, getPageById, resetApproveStateToWork } from '@/db/repository/page.repository';
-import { canWriteCms, getCurrentUser } from '@/lib/current-user';
+import { canAccessCmsEdit, canManageCmsPage, getCurrentUser } from '@/lib/current-user';
 import { isValidBankId, isPageExpired } from '@/lib/validators';
 import { successResponse, contentBuilderErrorResponse, getErrorMessage } from '@/lib/api-response';
 
@@ -16,15 +16,19 @@ async function savePage(
     thumbnail?: string,
     templateId?: string,
 ): Promise<void> {
-    const { userId, userName, authorities } = await getCurrentUser();
-    if (!canWriteCms({ authorities })) {
+    const currentUser = await getCurrentUser();
+    if (!canAccessCmsEdit(currentUser)) {
         throw new Error('권한이 없습니다.');
     }
+    const { userId, userName } = currentUser;
 
     // 1. 기존 페이지 확인 + 만료 체크
     const existing = await getPageById(bank);
     if (existing && isPageExpired(existing.IS_PUBLIC, existing.EXPIRED_DATE)) {
         throw new Error('만료된 페이지는 수정할 수 없습니다.');
+    }
+    if (existing && !canManageCmsPage(currentUser, existing.CREATE_USER_ID)) {
+        throw new Error('권한이 없습니다.');
     }
 
     // 2. DB 저장 (PAGE_HTML CLOB에 직접 기록)

--- a/src/app/api/builder/upload/route.ts
+++ b/src/app/api/builder/upload/route.ts
@@ -6,7 +6,7 @@ import { NextRequest } from 'next/server';
 
 import { createAsset } from '@/db/repository/asset.repository';
 import { contentBuilderErrorResponse, successResponse, getErrorMessage } from '@/lib/api-response';
-import { canWriteCms, getCurrentUser } from '@/lib/current-user';
+import { canAccessCmsEdit, getCurrentUser } from '@/lib/current-user';
 import { ASSET_UPLOAD_DIR, ASSET_BASE_URL, SERVER_MODE } from '@/lib/env';
 
 export async function POST(req: NextRequest) {
@@ -30,7 +30,7 @@ export async function POST(req: NextRequest) {
     try {
         // 권한 체크는 파일 바이트 로드 전에 수행 — 권한 없는 대용량 업로드 조기 차단
         const currentUser = await getCurrentUser();
-        if (!canWriteCms(currentUser)) {
+        if (!canAccessCmsEdit(currentUser)) {
             return contentBuilderErrorResponse('Permission denied.');
         }
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,7 +5,7 @@ import { existsSync } from 'fs';
 import { join } from 'path';
 
 import { getPageList } from '@/db/repository/page.repository';
-import { canReadCms, canWriteCms, getCurrentUser } from '@/lib/current-user';
+import { canAccessCmsDashboard, canManageCmsPage, getCurrentUser } from '@/lib/current-user';
 import { redirect } from 'next/navigation';
 import { isPageExpired } from '@/lib/validators';
 import { getApproveLabels } from '@/data/approve-config';
@@ -26,7 +26,7 @@ export default async function DashboardPage({
     const { page: pageParam, search: searchParam, sortBy: sortByParam, viewMode: viewModeParam } = await searchParams;
 
     const currentUser = await getCurrentUser();
-    if (!canReadCms(currentUser)) {
+    if (!canAccessCmsDashboard(currentUser)) {
         redirect('/not-authorized');
     }
 
@@ -73,7 +73,7 @@ export default async function DashboardPage({
             search={search}
             sortBy={sortBy}
             viewMode={viewMode ?? null}
-            canWrite={canWriteCms(currentUser)}
+            canWrite={canManageCmsPage(currentUser, currentUser.userId)}
             approveLabels={approveLabels}
         />
     );

--- a/src/app/edit/page.tsx
+++ b/src/app/edit/page.tsx
@@ -3,7 +3,8 @@
 import { Suspense } from 'react';
 
 import EditClientLoader from '@/components/edit/EditClientLoader';
-import { canReadCms, canWriteCms, getCurrentUser } from '@/lib/current-user';
+import { getPageById } from '@/db/repository/page.repository';
+import { canAccessCmsEdit, canManageCmsPage, getCurrentUser } from '@/lib/current-user';
 import { BANK_BRAND } from '@/lib/env';
 import { BRAND_THEMES, type BrandTheme } from '@/data/brand-themes';
 import { redirect } from 'next/navigation';
@@ -14,7 +15,12 @@ export default async function Edit({ searchParams }: { searchParams: Promise<{ b
     const params = await searchParams;
     const bank = params.bank || 'ibk';
     const currentUser = await getCurrentUser();
-    if (!canReadCms(currentUser)) {
+    if (!canAccessCmsEdit(currentUser)) {
+        redirect('/not-authorized');
+    }
+
+    const page = await getPageById(bank);
+    if (page && !canManageCmsPage(currentUser, page.CREATE_USER_ID)) {
         redirect('/not-authorized');
     }
 
@@ -28,7 +34,7 @@ export default async function Edit({ searchParams }: { searchParams: Promise<{ b
                 bank={bank}
                 userId={currentUser.userId}
                 brandTheme={brandTheme}
-                canWrite={canWriteCms(currentUser)}
+                canWrite={canManageCmsPage(currentUser, page?.CREATE_USER_ID)}
             />
         </Suspense>
     );

--- a/src/db/repository/page.repository.ts
+++ b/src/db/repository/page.repository.ts
@@ -236,7 +236,16 @@ export async function requestApproval(
     expiredDate: string,
 ): Promise<void> {
     await withTransaction(async (conn) => {
-        await conn.execute(PAGE_REQUEST_APPROVAL, { pageId, approverId, approverName, beginningDate, expiredDate });
+        const result = await conn.execute(PAGE_REQUEST_APPROVAL, {
+            pageId,
+            approverId,
+            approverName,
+            beginningDate,
+            expiredDate,
+        });
+        if ((result.rowsAffected ?? 0) === 0) {
+            throw new Error('승인 요청할 수 없는 상태입니다.');
+        }
     });
 }
 

--- a/src/lib/current-user.ts
+++ b/src/lib/current-user.ts
@@ -91,7 +91,7 @@ export function canWriteCms(user: Pick<CurrentUser, 'authorities'>): boolean {
 }
 
 export function canAccessCmsDashboard(user: Pick<CurrentUser, 'authorities'>): boolean {
-    return hasAuthority(user, 'CMS:R') && !hasAuthority(user, 'CMS:W');
+    return hasAuthority(user, 'CMS:R');
 }
 
 export function canManageAllCmsPages(user: Pick<CurrentUser, 'authorities'>): boolean {

--- a/src/lib/current-user.ts
+++ b/src/lib/current-user.ts
@@ -35,7 +35,7 @@ const BYPASS_ADMIN: CurrentUser = {
     userId: 'admin',
     userName: '관리자',
     roleId: 'cms_admin',
-    authorities: ['CMS:R', 'CMS:W'],
+    authorities: ['CMS:W'],
 };
 
 /** 인증 우회 모드 — 일반 사용자 (AUTH_BYPASS=true 기본값) */
@@ -43,7 +43,7 @@ const BYPASS_USER: CurrentUser = {
     userId: 'cmsUser01',
     userName: 'cms일반유저',
     roleId: 'cms_user',
-    authorities: ['CMS:R', 'CMS:W'],
+    authorities: ['CMS:R'],
 };
 
 /** AUTH_BYPASS 모드에서 쿠키 기반 역할 분기 */
@@ -88,6 +88,31 @@ export function canReadCms(user: Pick<CurrentUser, 'authorities'>): boolean {
 
 export function canWriteCms(user: Pick<CurrentUser, 'authorities'>): boolean {
     return hasAuthority(user, 'CMS:W');
+}
+
+export function canAccessCmsDashboard(user: Pick<CurrentUser, 'authorities'>): boolean {
+    return hasAuthority(user, 'CMS:R') && !hasAuthority(user, 'CMS:W');
+}
+
+export function canManageAllCmsPages(user: Pick<CurrentUser, 'authorities'>): boolean {
+    return hasAuthority(user, 'CMS:W');
+}
+
+export function canAccessCmsEdit(user: Pick<CurrentUser, 'authorities'>): boolean {
+    return hasAuthority(user, 'CMS:R') || hasAuthority(user, 'CMS:W');
+}
+
+export function canManageCmsPage(
+    user: Pick<CurrentUser, 'authorities' | 'userId'>,
+    ownerUserId?: string | null,
+): boolean {
+    if (canManageAllCmsPages(user)) {
+        return true;
+    }
+    if (!hasAuthority(user, 'CMS:R')) {
+        return false;
+    }
+    return !ownerUserId || ownerUserId === user.userId;
 }
 
 export const CMS_ROLE = {


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
> 연결된 이슈 번호를 적어주세요. (예: - #123)

- #31

## ✨ 변경 사항 (Changes)
> 무엇이 바뀌었는지 핵심 내용을 설명해 주세요.

- CMS 역할 정책에 맞춰 `Springware-CMS`의 현재 사용자 판별 및 권한 헬퍼를 정리했습니다.
- `current-user.ts`에 dashboard 접근, 전체 페이지 관리, 페이지 소유권 관리 관련 헬퍼를 추가/정리했습니다.
- `/dashboard`, `/edit` 진입 로직을 `CMS:R`, `CMS:W` 정책에 맞게 분기하도록 조정했습니다.
- builder 관련 API(`load`, `save`, `pages`, `approve-request`, `upload`)에서 소유권/권한 검증을 보강했습니다.
- `CMS:R` 사용자는 본인 페이지만 관리하고, `CMS:W` 사용자는 전체 페이지를 관리할 수 있도록 CMS 쪽 권한 흐름을 맞췄습니다.
- `PENDING` 상태 재승인요청 불가 정책을 유지하면서 결과 검증을 보강했습니다.
- `/dashboard` 접근 정책 완화에 맞춰 `CMS:R` 권한이 있으면 dashboard 접근이 가능하도록 정리했습니다.
- Playwright 기반 역할 정책 E2E를 추가/보강했습니다.

## 📸 변경 사항 확인 (선택)
> UI 변경이 있거나 결과물을 시각적으로 보여줄 수 있다면 첨부해 주세요.

| 변경 전 (Before) | 변경 후 (After) |
| :--- | :--- |
| CMS 권한 판단이 단순 `canReadCms` / `canWriteCms` 중심이라 역할 정책 반영이 부족함 | dashboard 접근, 전체 관리, 소유권 검증까지 역할 정책 기준으로 분리 |
| `CMS:R`와 `CMS:W`의 화면 접근 정책이 문서와 완전히 맞지 않음 | `/dashboard`, `/edit`, builder API가 정책 기준으로 동작 |
| 역할 정책에 대한 E2E 검증이 부족함 | Playwright로 역할별 접근 시나리오 추가 |

## ⚠️ 고려 및 주의 사항 (선택)
> 배포 시 유의점이나 기술적 부채, 향후 영향도를 적어주세요.

- 실제 로그인 세션 연동은 admin과 CMS Next 간 프록시/세션 이슈와 연결되므로, 이 부분은 별도 통합 이슈로 다루는 것이 적절합니다.
- 현재 워킹트리에는 이번 PR과 무관한 로컬 변경이 남아 있습니다.
  - `.idea/workspace.xml`
  - `src/instrumentation.ts`
  - `src/lib/scheduler.ts`
- 역할 E2E는 우선 현재 확보된 사용자/권한 정보 기준으로 보강했으며, 실제 pageId 기반 소유권 시나리오는 추가 데이터가 있으면 더 확장할 수 있습니다.

## 💬 리뷰 포인트 (선택)
> 특별히 신경 써서 봐주었으면 하는 부분이나 의견이 필요한 곳을 적어주세요.

- `canAccessCmsDashboard()`를 `CMS:R` 기준으로 완화한 방향이 admin 쪽 정책과 일관되는지 확인 부탁드립니다.
- `canManageCmsPage()`의 소유권 판정 기준이 현재 운영 데이터 구조와 맞는지 확인 부탁드립니다.
- builder API에서 권한/소유권 검증을 넣은 방식이 이후 프록시/세션 연동 변경과 충돌하지 않는지 확인 부탁드립니다.

## 🔗 참고 사항 (선택)
> 참고 자료 혹은 추가로 전달할 사항을 적어주세요.

주요 변경 파일:

- [current-user.ts](C:/workspace/neobns/Springware-CMS/src/lib/current-user.ts)
- [dashboard/page.tsx](C:/workspace/neobns/Springware-CMS/src/app/dashboard/page.tsx)
- [edit/page.tsx](C:/workspace/neobns/Springware-CMS/src/app/edit/page.tsx)
- [route.ts](C:/workspace/neobns/Springware-CMS/src/app/api/builder/load/route.ts)
- [route.ts](C:/workspace/neobns/Springware-CMS/src/app/api/builder/save/route.ts)
- [route.ts](C:/workspace/neobns/Springware-CMS/src/app/api/builder/pages/route.ts)
- [route.ts](C:/workspace/neobns/Springware-CMS/src/app/api/builder/pages/[pageId]/approve-request/route.ts)
- [route.ts](C:/workspace/neobns/Springware-CMS/src/app/api/builder/upload/route.ts)
- [page.repository.ts](C:/workspace/neobns/Springware-CMS/src/db/repository/page.repository.ts)
- [cms-role-policy.spec.ts](C:/workspace/neobns/Springware-CMS/e2e/pages/cms-role-policy.spec.ts)

관련 커밋:

- `0fd7a4d feat #31 : CMS 권한 정책 반영 및 역할 E2E 추가`
- `9cb830f feat #31 : CMS 대시보드 접근 권한 완화`
