### PR TITLE
feat: CORS 미들웨어 추가 — 운영 서버 트래킹 허용

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,39 @@
+// src/middleware.ts
+// CORS 응답 헤더 주입 — CORS_ALLOWED_ORIGINS에 등록된 오리진만 허용
+
+import { NextRequest, NextResponse } from 'next/server';
+
+const ALLOWED_ORIGINS = (process.env.CORS_ALLOWED_ORIGINS ?? '')
+    .split(',')
+    .map((o) => o.trim())
+    .filter(Boolean);
+
+function setCorsHeaders(res: NextResponse, origin: string): void {
+    res.headers.set('Access-Control-Allow-Origin', origin);
+    res.headers.set('Access-Control-Allow-Credentials', 'true');
+    res.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+    res.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization, x-deploy-token');
+}
+
+export function middleware(req: NextRequest): NextResponse {
+    const origin = req.headers.get('origin') ?? '';
+    const isAllowed = ALLOWED_ORIGINS.length > 0 && ALLOWED_ORIGINS.includes(origin);
+
+    // Preflight 요청 처리
+    if (req.method === 'OPTIONS') {
+        const res = new NextResponse(null, { status: 204 });
+        if (isAllowed) setCorsHeaders(res, origin);
+        return res;
+    }
+
+    const res = NextResponse.next();
+    if (isAllowed) setCorsHeaders(res, origin);
+    return res;
+}
+
+export const config = {
+    matcher: [
+        // API 라우트 및 페이지 라우트 모두 적용 (정적 파일·_next 제외)
+        '/((?!_next/static|_next/image|favicon.ico).*)',
+    ],
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,9 +10,11 @@ const ALLOWED_ORIGINS = (process.env.CORS_ALLOWED_ORIGINS ?? '')
 
 function setCorsHeaders(res: NextResponse, origin: string): void {
     res.headers.set('Access-Control-Allow-Origin', origin);
+    res.headers.append('Vary', 'Origin');
     res.headers.set('Access-Control-Allow-Credentials', 'true');
     res.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
     res.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization, x-deploy-token');
+    res.headers.set('Access-Control-Max-Age', '86400');
 }
 
 export function middleware(req: NextRequest): NextResponse {


### PR DESCRIPTION
## Summary
- `src/middleware.ts`가 untracked 상태로 서버에 배포되지 않아 CORS 처리가 전혀 동작하지 않던 문제 수정
- 배포된 HTML(운영 서버 `:3001`)에서 CMS API(`:3000`)로 `sendBeacon` 호출 시 CORS 정책 차단 해결

## 증상
```
Access to resource at 'http://133.186.135.23/cms/api/track/view' from origin 'http://133.186.135.23:3001'
has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present
```

## 원인
`src/middleware.ts`가 git untracked 상태 → 서버 이미지에 미포함 → CORS 헤더 미설정

## 동작 방식
- `CORS_ALLOWED_ORIGINS` 환경변수에 등록된 오리진만 허용
- OPTIONS preflight 요청 처리 (204 반환 + CORS 헤더)
- 허용된 오리진에 한해 `Access-Control-Allow-Origin` 등 CORS 헤더 주입

## 환경변수 설정 필요 (`.env.prod`)
```env
CORS_ALLOWED_ORIGINS=http://localhost:8080,http://localhost:9000,http://133.186.135.23:3001
```

## Test plan
- [ ] 운영 서버 배포 HTML 접속 후 브라우저 콘솔 CORS 에러 없음 확인
- [ ] `SPW_CMS_PAGE_VIEW_LOG` 테이블에 VIEW 로그 INSERT 확인
- [ ] 컴포넌트 클릭 시 CLICK 로그 INSERT 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)