### PR TITLE
[FIX]: 배포 미리보기 404, CI E2E 타임아웃, 트래커 CORS 수정

### DIFF
--- a/src/app/api/track/click/route.ts
+++ b/src/app/api/track/click/route.ts
@@ -5,23 +5,36 @@ import { NextRequest } from 'next/server';
 
 import { insertViewLog } from '@/db/repository/page-view-log.repository';
 import { successResponse, errorResponse, getErrorMessage } from '@/lib/api-response';
+import { TRACKER_CORS_ORIGIN } from '@/lib/env';
+
+// 배포 페이지(운영 서버 포트)에서 CMS API 호출 시 CORS 허용
+const CORS_HEADERS = {
+    'Access-Control-Allow-Origin': TRACKER_CORS_ORIGIN,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+};
+
+// CORS preflight 요청 처리
+export function OPTIONS() {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+}
 
 export async function POST(req: NextRequest) {
     try {
         const { pageId, componentId } = await req.json();
 
         if (!pageId || typeof pageId !== 'string') {
-            return errorResponse('pageId가 필요합니다.', 400);
+            return errorResponse('pageId가 필요합니다.', 400, CORS_HEADERS);
         }
         if (!componentId || typeof componentId !== 'string') {
-            return errorResponse('componentId가 필요합니다.', 400);
+            return errorResponse('componentId가 필요합니다.', 400, CORS_HEADERS);
         }
 
         await insertViewLog(pageId, 'CLICK', componentId);
 
-        return successResponse();
+        return successResponse(undefined, 200, CORS_HEADERS);
     } catch (err: unknown) {
         console.error('CLICK 로그 기록 실패:', err);
-        return errorResponse(getErrorMessage(err));
+        return errorResponse(getErrorMessage(err), 500, CORS_HEADERS);
     }
 }

--- a/src/app/api/track/click/route.ts
+++ b/src/app/api/track/click/route.ts
@@ -4,19 +4,17 @@
 import { NextRequest } from 'next/server';
 
 import { insertViewLog } from '@/db/repository/page-view-log.repository';
-import { successResponse, errorResponse, getErrorMessage } from '@/lib/api-response';
-import { TRACKER_CORS_ORIGIN } from '@/lib/env';
-
-// 배포 페이지(운영 서버 포트)에서 CMS API 호출 시 CORS 허용
-const CORS_HEADERS = {
-    'Access-Control-Allow-Origin': TRACKER_CORS_ORIGIN,
-    'Access-Control-Allow-Methods': 'POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type',
-};
+import {
+    successResponse,
+    errorResponse,
+    getErrorMessage,
+    TRACKER_CORS_HEADERS,
+    trackerCorsOptionsResponse,
+} from '@/lib/api-response';
 
 // CORS preflight 요청 처리
 export function OPTIONS() {
-    return new Response(null, { status: 204, headers: CORS_HEADERS });
+    return trackerCorsOptionsResponse();
 }
 
 export async function POST(req: NextRequest) {
@@ -24,17 +22,17 @@ export async function POST(req: NextRequest) {
         const { pageId, componentId } = await req.json();
 
         if (!pageId || typeof pageId !== 'string') {
-            return errorResponse('pageId가 필요합니다.', 400, CORS_HEADERS);
+            return errorResponse('pageId가 필요합니다.', 400, TRACKER_CORS_HEADERS);
         }
         if (!componentId || typeof componentId !== 'string') {
-            return errorResponse('componentId가 필요합니다.', 400, CORS_HEADERS);
+            return errorResponse('componentId가 필요합니다.', 400, TRACKER_CORS_HEADERS);
         }
 
         await insertViewLog(pageId, 'CLICK', componentId);
 
-        return successResponse(undefined, 200, CORS_HEADERS);
+        return successResponse(undefined, 200, TRACKER_CORS_HEADERS);
     } catch (err: unknown) {
         console.error('CLICK 로그 기록 실패:', err);
-        return errorResponse(getErrorMessage(err), 500, CORS_HEADERS);
+        return errorResponse(getErrorMessage(err), 500, TRACKER_CORS_HEADERS);
     }
 }

--- a/src/app/api/track/view/route.ts
+++ b/src/app/api/track/view/route.ts
@@ -5,20 +5,33 @@ import { NextRequest } from 'next/server';
 
 import { insertViewLog } from '@/db/repository/page-view-log.repository';
 import { successResponse, errorResponse, getErrorMessage } from '@/lib/api-response';
+import { TRACKER_CORS_ORIGIN } from '@/lib/env';
+
+// 배포 페이지(운영 서버 포트)에서 CMS API 호출 시 CORS 허용
+const CORS_HEADERS = {
+    'Access-Control-Allow-Origin': TRACKER_CORS_ORIGIN,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+};
+
+// CORS preflight 요청 처리
+export function OPTIONS() {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+}
 
 export async function POST(req: NextRequest) {
     try {
         const { pageId } = await req.json();
 
         if (!pageId || typeof pageId !== 'string') {
-            return errorResponse('pageId가 필요합니다.', 400);
+            return errorResponse('pageId가 필요합니다.', 400, CORS_HEADERS);
         }
 
         await insertViewLog(pageId, 'VIEW');
 
-        return successResponse();
+        return successResponse(undefined, 200, CORS_HEADERS);
     } catch (err: unknown) {
         console.error('VIEW 로그 기록 실패:', err);
-        return errorResponse(getErrorMessage(err));
+        return errorResponse(getErrorMessage(err), 500, CORS_HEADERS);
     }
 }

--- a/src/app/api/track/view/route.ts
+++ b/src/app/api/track/view/route.ts
@@ -4,19 +4,17 @@
 import { NextRequest } from 'next/server';
 
 import { insertViewLog } from '@/db/repository/page-view-log.repository';
-import { successResponse, errorResponse, getErrorMessage } from '@/lib/api-response';
-import { TRACKER_CORS_ORIGIN } from '@/lib/env';
-
-// 배포 페이지(운영 서버 포트)에서 CMS API 호출 시 CORS 허용
-const CORS_HEADERS = {
-    'Access-Control-Allow-Origin': TRACKER_CORS_ORIGIN,
-    'Access-Control-Allow-Methods': 'POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type',
-};
+import {
+    successResponse,
+    errorResponse,
+    getErrorMessage,
+    TRACKER_CORS_HEADERS,
+    trackerCorsOptionsResponse,
+} from '@/lib/api-response';
 
 // CORS preflight 요청 처리
 export function OPTIONS() {
-    return new Response(null, { status: 204, headers: CORS_HEADERS });
+    return trackerCorsOptionsResponse();
 }
 
 export async function POST(req: NextRequest) {
@@ -24,14 +22,14 @@ export async function POST(req: NextRequest) {
         const { pageId } = await req.json();
 
         if (!pageId || typeof pageId !== 'string') {
-            return errorResponse('pageId가 필요합니다.', 400, CORS_HEADERS);
+            return errorResponse('pageId가 필요합니다.', 400, TRACKER_CORS_HEADERS);
         }
 
         await insertViewLog(pageId, 'VIEW');
 
-        return successResponse(undefined, 200, CORS_HEADERS);
+        return successResponse(undefined, 200, TRACKER_CORS_HEADERS);
     } catch (err: unknown) {
         console.error('VIEW 로그 기록 실패:', err);
-        return errorResponse(getErrorMessage(err), 500, CORS_HEADERS);
+        return errorResponse(getErrorMessage(err), 500, TRACKER_CORS_HEADERS);
     }
 }

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -2,6 +2,22 @@
 
 import { NextResponse } from 'next/server';
 
+import { TRACKER_CORS_ORIGIN } from '@/lib/env';
+
+/**
+ * 트래커 API CORS 헬퍼 — 배포 페이지(운영 서버 포트)→CMS 크로스오리진 허용
+ * OPTIONS preflight 응답과 POST 응답 헤더에 공통 적용합니다.
+ */
+export const TRACKER_CORS_HEADERS: Record<string, string> = {
+    'Access-Control-Allow-Origin': TRACKER_CORS_ORIGIN,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+};
+
+export function trackerCorsOptionsResponse(): Response {
+    return new Response(null, { status: 204, headers: TRACKER_CORS_HEADERS });
+}
+
 /** 에러 객체에서 메시지 문자열 추출 */
 export function getErrorMessage(error: unknown): string {
     return error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다.';

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -8,16 +8,20 @@ export function getErrorMessage(error: unknown): string {
 }
 
 /** 일반 API 성공 응답 (HTTP 200) */
-export function successResponse<T extends Record<string, unknown>>(data?: T, status = 200): NextResponse {
-    return NextResponse.json({ ok: true, ...data }, { status });
+export function successResponse<T extends Record<string, unknown>>(
+    data?: T,
+    status = 200,
+    headers?: Record<string, string>,
+): NextResponse {
+    return NextResponse.json({ ok: true, ...data }, { status, headers });
 }
 
 /**
  * 일반 API 에러 응답 (HTTP 4xx/5xx)
  * ContentBuilder와 무관한 일반 Next.js API에서 사용합니다.
  */
-export function errorResponse(message: string, status = 500): NextResponse {
-    return NextResponse.json({ ok: false, error: message }, { status });
+export function errorResponse(message: string, status = 500, headers?: Record<string, string>): NextResponse {
+    return NextResponse.json({ ok: false, error: message }, { status, headers });
 }
 
 /**

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -56,6 +56,10 @@ export const GIT_USER_NAME = optionalEnv('GIT_USER_NAME', 'Springware CMS');
 export const GIT_USER_EMAIL = optionalEnv('GIT_USER_EMAIL', 'cms@springware.local');
 export const GIT_BRANCH = optionalEnv('GIT_BRANCH', 'main');
 
+// ── 트래커 CORS ──
+/** 배포 페이지에서 트래커 API 호출 시 허용할 오리진 (기본: * — 공개 수집 엔드포인트) */
+export const TRACKER_CORS_ORIGIN = optionalEnv('TRACKER_CORS_ORIGIN', '*');
+
 // ── Oracle DB ──
 export const ORACLE_USER = optionalEnv('ORACLE_USER');
 export const ORACLE_PASSWORD = optionalEnv('ORACLE_PASSWORD');


### PR DESCRIPTION
## Summary

- **nginx**: 8080 포트에 `/cms/deployed/` 블록 추가 — 배포된 HTML을 Next.js 없이 파일시스템에서 직접 서빙 (재기동 불필요)
- **CI E2E**: `webServer.url`을 `/api/health`로 변경 — Oracle 없는 환경에서 타임아웃 해소
- **CI E2E**: `ORACLE_DISABLED=true` 환경에서 대시보드 빈 목록 폴백 추가
- **Auth**: `BYPASS_ADMIN` 권한에 `CMS:R` 추가 — cms_admin 유저가 `/dashboard` 접근 가능
- **CORS**: 트래커 API(`/api/track/view`, `/api/track/click`)에 CORS 헤더 추가 — 운영 서버(:8080)→CMS(:80) 크로스오리진 허용

## Test plan

- [ ] 배포 후 미리보기 URL(`:8080/cms/deployed/...`) 정상 로드 확인
- [ ] CI E2E 전체 통과 확인
- [ ] 배포 페이지 열었을 때 콘솔에 CORS 에러 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)