### PR TITLE
[FIX #57]: 이미지 승인 deploy API 403 — x-deploy-token 인증으로 교체

### DIFF
--- a/src/app/api/assets/[assetId]/deploy/route.ts
+++ b/src/app/api/assets/[assetId]/deploy/route.ts
@@ -17,18 +17,16 @@ import { NextRequest } from 'next/server';
 
 import { getAssetById, updateAssetPathUrl } from '@/db/repository/asset.repository';
 import { successResponse, errorResponse, getErrorMessage } from '@/lib/api-response';
-import { DEPLOYED_UPLOAD_DIR, DEPLOYED_BASE_URL, DEPLOYED_IMG_SUBDIR } from '@/lib/env';
-
-const DEPLOY_SECRET = process.env.DEPLOY_SECRET ?? '';
+import { DEPLOY_SECRET, DEPLOYED_UPLOAD_DIR, DEPLOYED_BASE_URL, DEPLOYED_IMG_SUBDIR } from '@/lib/env';
 
 /** 타이밍 공격 방지 토큰 비교 */
 function isValidToken(token: string | null): boolean {
     if (!DEPLOY_SECRET || !token) return false;
     try {
-        const 기대값 = Buffer.from(DEPLOY_SECRET, 'utf8');
-        const 수신값 = Buffer.from(token, 'utf8');
-        if (기대값.length !== 수신값.length) return false;
-        return timingSafeEqual(기대값, 수신값);
+        const expected = Buffer.from(DEPLOY_SECRET, 'utf8');
+        const received = Buffer.from(token, 'utf8');
+        if (expected.length !== received.length) return false;
+        return timingSafeEqual(expected, received);
     } catch {
         return false;
     }

--- a/src/app/api/deploy/receive/route.ts
+++ b/src/app/api/deploy/receive/route.ts
@@ -7,17 +7,16 @@ import path from 'path';
 import { NextRequest } from 'next/server';
 
 import { errorResponse, getErrorMessage, successResponse } from '@/lib/api-response';
-
-const DEPLOY_SECRET = process.env.DEPLOY_SECRET ?? '';
+import { DEPLOY_SECRET } from '@/lib/env';
 
 /** 타이밍 공격 방지 토큰 비교 */
 function isValidToken(token: string | null): boolean {
     if (!DEPLOY_SECRET || !token) return false;
     try {
-        const 기대값 = Buffer.from(DEPLOY_SECRET, 'utf8');
-        const 수신값 = Buffer.from(token, 'utf8');
-        if (기대값.length !== 수신값.length) return false;
-        return timingSafeEqual(기대값, 수신값);
+        const expected = Buffer.from(DEPLOY_SECRET, 'utf8');
+        const received = Buffer.from(token, 'utf8');
+        if (expected.length !== received.length) return false;
+        return timingSafeEqual(expected, received);
     } catch {
         return false;
     }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -56,6 +56,10 @@ export const GIT_USER_NAME = optionalEnv('GIT_USER_NAME', 'Springware CMS');
 export const GIT_USER_EMAIL = optionalEnv('GIT_USER_EMAIL', 'cms@springware.local');
 export const GIT_BRANCH = optionalEnv('GIT_BRANCH', 'main');
 
+// ── 배포 보안 ──
+/** 서버간 배포 API 인증 토큰 (Spider Admin → CMS, CMS → 운영 서버) */
+export const DEPLOY_SECRET = optionalEnv('DEPLOY_SECRET');
+
 // ── 트래커 CORS ──
 /** 배포 페이지에서 트래커 API 호출 시 허용할 오리진 (기본: * — 공개 수집 엔드포인트) */
 export const TRACKER_CORS_ORIGIN = optionalEnv('TRACKER_CORS_ORIGIN', '*');


### PR DESCRIPTION
## Summary

- Spider Admin이 이미지 승인 후 `POST /cms/api/assets/{assetId}/deploy` 호출 시 403 발생하는 문제 수정
- 세션 기반 인증(`getCurrentUser()`) → `x-deploy-token` 헤더 + `DEPLOY_SECRET` 인증으로 교체
- `deploy/receive` 엔드포인트와 동일한 인증 패턴 적용

## Test plan

- [ ] Spider Admin에서 이미지 승인 시 403 없이 정상 처리 확인
- [ ] `x-deploy-token` 헤더 없이 호출 시 401 반환 확인
- [ ] Spider Admin 쪽 `CmsBuilderClient.deployAsset()`에 `x-deploy-token` 헤더 추가 필요

closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)