### PR TITLE
fix(tracker): sendBeacon Blob 타입을 text/plain으로 변경 — CORS preflight 제거

### DIFF
--- a/public/cms-tracker.js
+++ b/public/cms-tracker.js
@@ -12,11 +12,12 @@
     const viewUrl = cmsUrl + '/api/track/view';
     const clickUrl = cmsUrl + '/api/track/click';
 
-    // 페이지 조회 전송 (Blob으로 application/json Content-Type 보장)
+    // 페이지 조회 전송
+    // text/plain — CORS simple request이므로 preflight 없이 크로스오리진 전송 가능
     try {
         navigator.sendBeacon(
             viewUrl,
-            new Blob([JSON.stringify({ pageId: pageId })], { type: 'application/json' }),
+            new Blob([JSON.stringify({ pageId: pageId })], { type: 'text/plain' }),
         );
     } catch (e) {
         console.error('CMS Tracker (view) failed:', e);
@@ -33,7 +34,7 @@
             navigator.sendBeacon(
                 clickUrl,
                 new Blob([JSON.stringify({ pageId: pageId, componentId: componentId })], {
-                    type: 'application/json',
+                    type: 'text/plain',
                 }),
             );
         } catch (ex) {


### PR DESCRIPTION
application/json은 CORS preflight를 발생시키고 credentials mode 'include' 시 wildcard origin 차단됨. text/plain은 simple request로 preflight 없이 크로스오리진 전송 가능. req.json()은 Content-Type 무관하게 파싱되므로
서버 측 변경 불필요.

## 🔗 관련 이슈 (Related Issues)
> 연결된 이슈 번호를 적어주세요. (예: - #123)

## ✨ 변경 사항 (Changes)
> 무엇이 바뀌었는지 핵심 내용을 설명해 주세요.

## 📸 변경 사항 확인 (선택)
> UI 변경이 있거나 결과물을 시각적으로 보여줄 수 있다면 첨부해 주세요.

| 변경 전 (Before) | 변경 후 (After) |
| :--- | :--- |
| (이미지/GIF) | (이미지/GIF) |

## ⚠️ 고려 및 주의 사항 (선택)
> 배포 시 유의점이나 기술적 부채, 향후 영향도를 적어주세요.

## 💬 리뷰 포인트 (선택)
> 특별히 신경 써서 봐주었으면 하는 부분이나 의견이 필요한 곳을 적어주세요.

## 🔗 참고 사항 (선택)
> 참고 자료 혹은 추가로 전달할 사항을 적어주세요.
