### PR TITLE
[FEATURE #63]: asset image 엔드포인트 redirect → 파일 직접 스트리밍으로 변경

### DIFF
--- a/src/app/api/assets/[assetId]/image/route.ts
+++ b/src/app/api/assets/[assetId]/image/route.ts
@@ -1,22 +1,43 @@
 // src/app/api/assets/[assetId]/image/route.ts
-// 에셋 이미지 URL redirect API (하위 호환)
+// 에셋 이미지 스트리밍 API — Admin 서버 등 서버 간 호출용
+// ASSET_PATH에서 파일을 직접 읽어 반환 (URL 매핑 의존 없음)
+
+import { readFile } from 'fs/promises';
 
 import { NextRequest } from 'next/server';
 
 import { getAssetById } from '@/db/repository/asset.repository';
 import { errorResponse, getErrorMessage } from '@/lib/api-response';
 
-/** GET /api/assets/:assetId/image — ASSET_URL로 302 redirect (기존 URL 하위 호환) */
+/** GET /api/assets/:assetId/image — 이미지 파일 직접 스트리밍 */
 export async function GET(req: NextRequest, { params }: { params: Promise<{ assetId: string }> }) {
     try {
         const { assetId } = await params;
 
         const asset = await getAssetById(assetId);
-        if (!asset || !asset.ASSET_URL) {
+        if (!asset) {
             return errorResponse('이미지를 찾을 수 없습니다.', 404);
         }
 
-        return Response.redirect(new URL(asset.ASSET_URL, req.url), 302);
+        if (!asset.ASSET_PATH) {
+            return errorResponse('이미지 경로 정보가 없습니다.', 404);
+        }
+
+        let buffer: Buffer;
+        try {
+            buffer = await readFile(asset.ASSET_PATH);
+        } catch {
+            return errorResponse('이미지 파일을 찾을 수 없습니다.', 404);
+        }
+
+        return new Response(buffer, {
+            status: 200,
+            headers: {
+                'Content-Type': asset.MIME_TYPE || 'application/octet-stream',
+                'Content-Length': buffer.length.toString(),
+                'Cache-Control': 'public, max-age=3600',
+            },
+        });
     } catch (err: unknown) {
         console.error('에셋 이미지 조회 실패:', err);
         return errorResponse(getErrorMessage(err));

--- a/src/app/api/assets/[assetId]/image/route.ts
+++ b/src/app/api/assets/[assetId]/image/route.ts
@@ -2,14 +2,23 @@
 // 에셋 이미지 스트리밍 API — Admin 서버 등 서버 간 호출용
 // ASSET_PATH에서 파일을 직접 읽어 반환 (URL 매핑 의존 없음)
 
-import { readFile } from 'fs/promises';
+import { openAsBlob } from 'fs';
+import { resolve } from 'path';
 
 import { NextRequest } from 'next/server';
 
 import { getAssetById } from '@/db/repository/asset.repository';
 import { errorResponse, getErrorMessage } from '@/lib/api-response';
+import { ASSET_UPLOAD_DIR, DEPLOYED_UPLOAD_DIR } from '@/lib/env';
 
-/** GET /api/assets/:assetId/image — 이미지 파일 직접 스트리밍 */
+/** 허용된 디렉토리 내 경로인지 검증 (Path Traversal 방지) */
+function isAllowedPath(filePath: string): boolean {
+    const resolved = resolve(filePath);
+    const allowedDirs = [resolve(ASSET_UPLOAD_DIR), resolve(DEPLOYED_UPLOAD_DIR)];
+    return allowedDirs.some((dir) => resolved.startsWith(dir + '/') || resolved === dir);
+}
+
+/** GET /api/assets/:assetId/image — 이미지 파일 스트리밍 */
 export async function GET(req: NextRequest, { params }: { params: Promise<{ assetId: string }> }) {
     try {
         const { assetId } = await params;
@@ -23,18 +32,25 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ asse
             return errorResponse('이미지 경로 정보가 없습니다.', 404);
         }
 
-        let buffer: Buffer;
+        // Path Traversal 방지 — 허용된 디렉토리 외 접근 차단
+        if (!isAllowedPath(asset.ASSET_PATH)) {
+            return errorResponse('허용되지 않은 파일 경로입니다.', 403);
+        }
+
+        let blob: Blob;
         try {
-            buffer = await readFile(asset.ASSET_PATH);
+            blob = await openAsBlob(asset.ASSET_PATH, {
+                type: asset.MIME_TYPE || 'application/octet-stream',
+            });
         } catch {
             return errorResponse('이미지 파일을 찾을 수 없습니다.', 404);
         }
 
-        return new Response(new Uint8Array(buffer), {
+        return new Response(blob, {
             status: 200,
             headers: {
                 'Content-Type': asset.MIME_TYPE || 'application/octet-stream',
-                'Content-Length': buffer.length.toString(),
+                'Content-Length': blob.size.toString(),
                 'Cache-Control': 'public, max-age=3600',
             },
         });

--- a/src/app/api/assets/[assetId]/image/route.ts
+++ b/src/app/api/assets/[assetId]/image/route.ts
@@ -30,7 +30,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ asse
             return errorResponse('이미지 파일을 찾을 수 없습니다.', 404);
         }
 
-        return new Response(buffer, {
+        return new Response(new Uint8Array(buffer), {
             status: 200,
             headers: {
                 'Content-Type': asset.MIME_TYPE || 'application/octet-stream',


### PR DESCRIPTION
## 관련 이슈
closes #63

## 변경 내용
`GET /cms/api/assets/{assetId}/image` 엔드포인트를 302 redirect에서 파일 직접 스트리밍으로 변경.

**변경 전:** `ASSET_URL`로 302 redirect → nginx 경로 불일치로 Admin 서버에서 404 발생
**변경 후:** `ASSET_PATH`에서 파일 직접 읽어 bytes 반환

## 영향 범위
- CMS 내부에서 `/image` 엔드포인트를 사용하는 코드 없음 → 내부 영향 없음
- Admin 서버에서 이미지 썸네일·미리보기 조회 시 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)