### PR TITLE
[FEATURE #66]: 에디터 내 로컬 파일 업로드 차단 + 이미지 브라우저 연동 확대

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -200,17 +200,23 @@ body.spw-slide-modal-open .is-rte-tool {
     pointer-events: none;
 }
 
-/* ── ContentBuilder 배경 이미지 로컬 업로드 제거 ──
- * 설정 → 배경 이미지 패널의 로컬 파일 업로드 영역(`.image-larger1~4` wrapper + 내부 `.form-upload-larger`)은
- * OS 파일 선택창을 직접 띄워 /cms/files 승인 이미지 선택 흐름을 우회한다.
- * 숨겨서 같은 패널의 "Open Asset"(imageSelect=/cms/files) 버튼만 남긴다.
- * ContentBuilder 내부 자동 숨김(largerImageHandler 미설정 시)이 모든 컨텍스트를 커버하지 못하므로
- * 보수적으로 CSS로 강제 차단한다.
+/* ── ContentBuilder 로컬 파일 업로드 버튼 전면 차단 ──────────────────────────
+ * /cms/files 승인 이미지 브라우저만 사용하도록 OS 파일 선택 경로를 모두 숨긴다.
+ *
+ * [1] 배경 이미지 패널 — .image-larger1~4 래퍼 + 내부 .form-upload-larger
+ *     ContentBuilder 내부 자동 숨김이 모든 컨텍스트를 커버하지 못하므로 CSS로 강제 차단.
+ *
+ * [2] 링크 편집 모달 등 범용 업로드 버튼 — .div-anyfile-upload (.is-btn 래퍼)
+ *     .form-upload-larger 만 숨기면 부모 div(50×43 px)가 빈 공간으로 남으므로
+ *     래퍼 자체를 숨긴다. :has() 선택자로 form을 포함하는 .is-btn도 함께 차단.
  */
 .form-upload-larger,
 .image-larger1,
 .image-larger2,
 .image-larger3,
-.image-larger4 {
+.image-larger4,
+.div-anyfile-upload,
+.is-btn:has(> .form-upload-larger),
+.input-upload:has(> .form-upload-larger) {
     display: none !important;
 }

--- a/src/components/edit/FlexListEditor.tsx
+++ b/src/components/edit/FlexListEditor.tsx
@@ -736,6 +736,18 @@ function ColumnEditor({
 }) {
     const [showIconPicker, setShowIconPicker] = useState(false);
 
+    // 항상 최신 col을 참조 — 팝업이 열려있는 동안 다른 필드가 바뀌어도 덮어쓰지 않도록
+    const colRef = useRef(col);
+    colRef.current = col;
+
+    // 이미지 선택 팝업 메시지 리스너 클린업 (누적 방지)
+    const pickerCleanupRef = useRef<(() => void) | null>(null);
+    useEffect(() => {
+        return () => {
+            pickerCleanupRef.current?.();
+        };
+    }, []);
+
     return (
         <div
             style={{
@@ -989,7 +1001,6 @@ function ColumnEditor({
                     <input
                         type="text"
                         value={col.imageSrc ?? ''}
-                        onChange={(e) => onUpdate(colIdx, { ...col, imageSrc: e.target.value || undefined })}
                         placeholder="이미지 URL"
                         readOnly
                         style={{
@@ -1007,10 +1018,12 @@ function ColumnEditor({
                     <button
                         type="button"
                         onClick={() => {
+                            pickerCleanupRef.current?.(); // 이전 리스너 정리
                             try {
-                                openCmsFilesPicker((url) => {
-                                    onUpdate(colIdx, { ...col, imageSrc: url });
+                                const cleanup = openCmsFilesPicker((url) => {
+                                    onUpdate(colIdx, { ...colRef.current, imageSrc: url });
                                 });
+                                pickerCleanupRef.current = cleanup ?? null;
                             } catch {
                                 alert('이미지 선택 창을 열 수 없습니다. 팝업 차단을 확인해 주세요.');
                             }

--- a/src/components/edit/FlexListEditor.tsx
+++ b/src/components/edit/FlexListEditor.tsx
@@ -6,6 +6,8 @@
 
 import { useState, useCallback, useEffect, useRef } from 'react';
 
+import { openCmsFilesPicker } from '@/lib/cms-file-picker';
+
 // ── 데이터 모델 ──────────────────────────────────────────────────────────
 
 interface FlexListLine {
@@ -983,23 +985,76 @@ function ColumnEditor({
                         </span>
                     )}
 
-                    {/* URL 직접 입력 */}
+                    {/* URL 입력 + 이미지 브라우저 선택 */}
                     <input
                         type="text"
                         value={col.imageSrc ?? ''}
                         onChange={(e) => onUpdate(colIdx, { ...col, imageSrc: e.target.value || undefined })}
-                        placeholder="이미지 URL (직접 입력)"
+                        placeholder="이미지 URL"
+                        readOnly
                         style={{
                             flex: 1,
-                            minWidth: 100,
+                            minWidth: 80,
                             padding: '4px 8px',
                             border: '1px solid #e5e7eb',
                             borderRadius: 4,
                             fontSize: 11,
                             fontFamily: FONT_FAMILY,
                             outline: 'none',
+                            background: '#f9fafb',
                         }}
                     />
+                    <button
+                        type="button"
+                        onClick={() => {
+                            try {
+                                openCmsFilesPicker((url) => {
+                                    onUpdate(colIdx, { ...col, imageSrc: url });
+                                });
+                            } catch {
+                                alert('이미지 선택 창을 열 수 없습니다. 팝업 차단을 확인해 주세요.');
+                            }
+                        }}
+                        style={{
+                            padding: '4px 8px',
+                            border: '1px solid #C7D8F4',
+                            borderRadius: 4,
+                            background: '#F0F4FF',
+                            color: '#0046A4',
+                            fontSize: 11,
+                            fontWeight: 600,
+                            cursor: 'pointer',
+                            whiteSpace: 'nowrap',
+                            flexShrink: 0,
+                        }}
+                    >
+                        이미지 선택
+                    </button>
+                    {col.imageSrc && (
+                        <button
+                            type="button"
+                            title="이미지 제거"
+                            onClick={() => onUpdate(colIdx, { ...col, imageSrc: undefined })}
+                            style={{
+                                ...S.deleteBtn,
+                                width: 22,
+                                height: 22,
+                                flexShrink: 0,
+                            }}
+                        >
+                            <svg
+                                viewBox="0 0 24 24"
+                                width="9"
+                                height="9"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="2.5"
+                                strokeLinecap="round"
+                            >
+                                <path d="M18 6 6 18M6 6l12 12" />
+                            </svg>
+                        </button>
+                    )}
 
                     {/* 형태 선택 */}
                     <select

--- a/src/components/files/AssetBrowser.tsx
+++ b/src/components/files/AssetBrowser.tsx
@@ -239,16 +239,14 @@ export default function AssetBrowser({ assetOrigin = '' }: AssetBrowserProps) {
         setSelectedUrl((prev) => (prev === url ? null : url));
     }
 
-    // 우측 상단 X — 팝업으로 열린 경우 창 닫기, 직접 접근한 경우 이전 페이지로
+    // 우측 상단 X — 팝업 창 닫기
+    // window.history.back()은 사용하지 않음:
+    //   Next.js SSR 인증 redirect 등으로 opener가 null이 되는 경우,
+    //   history.back()이 에디터 메인 창이 아닌 팝업 창의 히스토리를 이동시켜
+    //   에디터 화면으로 돌아오지 못하는 버그가 생긴다.
     function handleClose() {
         if (typeof window === 'undefined') return;
-        if (window.opener) {
-            window.close();
-            return;
-        }
-        if (window.history.length > 1) {
-            window.history.back();
-        }
+        window.close();
     }
 
     function handleConfirm() {


### PR DESCRIPTION
## 개요

Issue #66 — 에디터에서 로컬 파일 업로드 경로를 완전히 차단하고, 승인된 이미지 브라우저(`/cms/files`)를 통해서만 이미지를 삽입하도록 강제합니다.

PR #67 머지 내용 위에 추가 작업한 두 건입니다.

## 변경 사항

### 1. `src/app/globals.css` — 로컬 업로드 버튼 완전 차단

PR #67에서 `.form-upload-larger`, `.image-larger1~4`를 숨겼으나, 링크 편집 모달의 **부모 래퍼**(`div.div-anyfile-upload.is-btn.classic`)가 50×43px 빈 공간으로 남아 있었습니다.

추가된 선택자:
- `.div-anyfile-upload` — 링크 편집 모달의 빈 래퍼 직접 은닉
- `.is-btn:has(> .form-upload-larger)` — `.is-btn` 래퍼가 업로드 폼을 포함하는 경우 은닉
- `.input-upload:has(> .form-upload-larger)` — `.input-upload` 래퍼 포함 케이스 은닉

### 2. `src/components/edit/FlexListEditor.tsx` — FlexList 이미지 컬럼에 브라우저 연동

`flex-list-*` 컴포넌트의 이미지 타입 컬럼 편집 시 OS 파일 선택창 대신 `openCmsFilesPicker`를 사용합니다.
- 승인된 이미지(`/cms/files`)에서만 선택 가능
- URL 직접 입력란은 읽기 전용으로 변경
- 이미지 제거 버튼 추가

## 테스트

- [ ] 에디터 캔버스에서 이미지 블록 클릭 → 파일 업로드 버튼(빈 공간 포함) 완전히 사라짐
- [ ] 링크 편집 모달(`이미지 삽입` 탭)에서 50×43px 빈 공간 없음
- [ ] `flex-list-*` 컴포넌트 편집 → 이미지 컬럼의 **이미지 선택** 버튼 → `/cms/files` 팝업 열림
- [ ] 팝업에서 이미지 선택 시 URL 자동 입력 및 미리보기 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)