### PR TITLE
fix : builder/upload API 복원 — Spider Admin 업로드 연동 복구

### DIFF
--- a/src/app/api/builder/upload/route.ts
+++ b/src/app/api/builder/upload/route.ts
@@ -1,5 +1,76 @@
-import { contentBuilderErrorResponse } from '@/lib/api-response';
+import crypto from 'crypto';
+import { mkdir, unlink, writeFile } from 'fs/promises';
+import { dirname, join } from 'path';
 
-export async function POST() {
-    return contentBuilderErrorResponse('이미지 업로드는 cms/files에서 승인된 이미지를 선택해 주세요.');
+import { NextRequest } from 'next/server';
+
+import { createAsset } from '@/db/repository/asset.repository';
+import { contentBuilderErrorResponse, getErrorMessage, successResponse } from '@/lib/api-response';
+import { normalizeCmsAssetCategory } from '@/lib/codes';
+import { canAccessCmsEdit, getCurrentUser } from '@/lib/current-user';
+import { ASSET_BASE_URL, ASSET_UPLOAD_DIR, SERVER_MODE } from '@/lib/env';
+
+export async function POST(req: NextRequest) {
+    if (SERVER_MODE === 'operation') {
+        return contentBuilderErrorResponse('이미지 업로드는 관리자 서버에서만 가능합니다.');
+    }
+
+    const formData = await req.formData();
+    const file = formData.get('file') as File | null;
+
+    if (!file) {
+        return contentBuilderErrorResponse('File is required.');
+    }
+
+    const bodyUserId = formData.get('userId')?.toString() || null;
+    const bodyUserName = formData.get('userName')?.toString() || null;
+    const businessCategoryInput = formData.get('businessCategory')?.toString() || null;
+    const assetDesc = formData.get('assetDesc')?.toString() || null;
+
+    try {
+        const currentUser = await getCurrentUser();
+        if (!canAccessCmsEdit(currentUser)) {
+            return contentBuilderErrorResponse('Permission denied.');
+        }
+
+        const userId = bodyUserId ?? currentUser.userId;
+        const userName = bodyUserId ? (bodyUserName ?? userId) : currentUser.userName;
+        const businessCategory = await normalizeCmsAssetCategory(businessCategoryInput);
+
+        const buffer = Buffer.from(await file.arrayBuffer());
+        const assetId = crypto.randomUUID();
+        const assetName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_');
+
+        const filename = `${assetId}_${assetName}`;
+        const filepath = join(ASSET_UPLOAD_DIR, filename);
+        await mkdir(dirname(filepath), { recursive: true });
+        await writeFile(filepath, buffer);
+        const assetUrl = `${ASSET_BASE_URL}/${filename}`;
+
+        try {
+            await createAsset({
+                assetId,
+                assetName,
+                businessCategory,
+                mimeType: file.type || 'application/octet-stream',
+                fileSize: buffer.length,
+                assetPath: filepath,
+                assetUrl,
+                assetDesc: assetDesc ?? undefined,
+                createUserId: userId,
+                createUserName: userName,
+            });
+        } catch (dbErr: unknown) {
+            await unlink(filepath).catch(() => {});
+            throw dbErr;
+        }
+
+        return successResponse({ url: assetUrl, assetId }, 201);
+    } catch (err: unknown) {
+        if (err instanceof Error && err.message === '유효하지 않은 이미지 카테고리입니다.') {
+            return contentBuilderErrorResponse(err.message);
+        }
+        console.error('File upload failed:', err);
+        return contentBuilderErrorResponse(getErrorMessage(err));
+    }
 }


### PR DESCRIPTION
PR #51에서 에디터 내 업로드 차단 목적으로 API 자체를 에러 응답으로 대체했으나,
Spider Admin(Java)이 동일 엔드포인트를 통해 이미지를 업로드하므로 연동이 깨짐.

에디터 UI 업로드 차단은 CSS로 충분 (globals.css .form-upload-larger 등 은닉). API는 실제 업로드 로직으로 복원하고 SERVER_MODE=operation 시에만 차단 유지.

## 🔗 관련 이슈 (Related Issues)
> 연결된 이슈 번호를 적어주세요. (예: - #123)

## ✨ 변경 사항 (Changes)
> 무엇이 바뀌었는지 핵심 내용을 설명해 주세요.

## 📸 변경 사항 확인 (선택)
> UI 변경이 있거나 결과물을 시각적으로 보여줄 수 있다면 첨부해 주세요.

| 변경 전 (Before) | 변경 후 (After) |
| :--- | :--- |
| (이미지/GIF) | (이미지/GIF) |

## ⚠️ 고려 및 주의 사항 (선택)
> 배포 시 유의점이나 기술적 부채, 향후 영향도를 적어주세요.

## 💬 리뷰 포인트 (선택)
> 특별히 신경 써서 봐주었으면 하는 부분이나 의견이 필요한 곳을 적어주세요.

## 🔗 참고 사항 (선택)
> 참고 자료 혹은 추가로 전달할 사항을 적어주세요.
