### PR TITLE
docs: 기술-개요·워크플로-분석 현행화 (#71)

### DIFF
--- a/docs/reference/기술-개요.md
+++ b/docs/reference/기술-개요.md
@@ -1,18 +1,23 @@
 # Springware CMS — 기술 개요
 
+> 최종 업데이트: 2026-04-23
+
 ## 1. 기술 스택
 
 | 항목 | 버전 | 용도 |
 |------|------|------|
-| **Next.js** | 15.5.4 | 메인 프레임워크 (App Router) |
+| **Next.js** | 15.5.4 | 메인 프레임워크 (App Router, basePath: `/cms`) |
 | **React** | 19.1.0 | UI 라이브러리 |
 | **TypeScript** | ^5 | 정적 타입 |
 | **Tailwind CSS** | ^4 | 스타일링 |
+| **oracledb** | ^6.10.0 | Oracle DB 드라이버 |
+| **node-cron** | ^4.2.1 | 내장 만료 페이지 스케줄러 |
+| **jose** | ^6.2.2 | JWT 서명·검증 (Spider Admin 세션 인증) |
 | **@innovastudio/contentbuilder** | ^1.5.192 | 비주얼 웹 에디터 (핵심) |
 | **@innovastudio/contentbuilder-runtime** | ^1.0.33 | 저장된 콘텐츠 렌더링 |
 | **@fal-ai/client** | ^1.6.2 | FAL AI 이미지 생성 |
 | **axios** | ^1.12.2 | HTTP 클라이언트 |
-| **html2canvas** | ^1.x | 페이지 썸네일 캡처 (에디터 Save 시) |
+| **html2canvas** | ^1.4.1 | 페이지 썸네일 캡처 (에디터 Save 시) |
 | **lucide-react** | ^0.544.0 | 아이콘 |
 
 **Path Alias**: `@/*` → `./src/*`
@@ -21,14 +26,13 @@
 
 App Router의 핵심 개념
 - app/ 폴더 안의 page.tsx가 곧 url 경로
-  - app/edit/page.tsx → /edit
-  - app/api/builder/save/route.ts → /api/builder/save
+  - app/edit/page.tsx → /cms/edit
+  - app/api/builder/save/route.ts → /cms/api/builder/save
 - 기본적으로 서버에서 실행되는 서버 컴포넌트
-  - 클라이언트에서 실행해야 하면 파일 맨 위에 'use clinet' 선언 필요
-  - EditClient.tsx 1번째 줄이 'use client'인 이유가 이것
+  - 클라이언트에서 실행해야 하면 파일 맨 위에 `'use client'` 선언 필요
+  - EditClient.tsx 1번째 줄이 `'use client'`인 이유가 이것
 - layout.tsx — 여러 페이지가 공유하는 공통 레이아웃 (헤더/푸터 등)
-
-쉽게 말하면 "Next.js가 파일/폴더 구조를 보고 URL을 자동으로 만들어주는 방식"이고, 이 프로젝트는 그 최신 버전(App Router)을 쓰고 있다.
+- `basePath: '/cms'` — 모든 URL 앞에 `/cms` 접두사가 붙음. 내부 링크 생성 시 `nextApi()` 유틸 사용
 
 ---
 
@@ -49,6 +53,8 @@ App Router의 핵심 개념
 | `/api/builder/pages/[pageId]/rollback` | POST | 이력 롤백 |
 | `/api/builder/pages/[pageId]/set-public` | POST | 공개 상태 설정 |
 | `/api/builder/pages/[pageId]/update-dates` | POST | 게시·만료일 수정 |
+| `/api/builder/ab` | GET/POST | A/B 테스트 그룹 관리 |
+| `/api/builder/ab/promote` | POST | A/B 테스트 승격 |
 
 ### 2.2 에셋 관리 (`/api/assets/*`)
 
@@ -57,8 +63,53 @@ App Router의 핵심 개념
 | `/api/assets` | GET/POST | 에셋 목록 조회·등록 |
 | `/api/assets/[assetId]` | GET/PUT/DELETE | 에셋 단건 조회·수정·삭제 |
 | `/api/assets/[assetId]/image` | GET | 에셋 이미지 직접 조회 |
+| `/api/assets/[assetId]/deploy` | POST | 승인된 에셋 파일 이동 (`uploads/` → `deployed/img/`) |
 
-### 2.3 AI 텍스트 생성
+### 2.3 파일 브라우저 (`/api/manage/*`)
+
+| 엔드포인트 | 메서드 | 역할 |
+|-----------|--------|------|
+| `/api/manage/files` | GET/POST/DELETE | 파일 목록 조회·업로드·삭제 |
+| `/api/manage/folders` | GET/POST/DELETE | 폴더 목록 조회·생성·삭제 |
+
+### 2.4 배포 (`/api/deploy/*`)
+
+| 엔드포인트 | 메서드 | 역할 |
+|-----------|--------|------|
+| `/api/deploy/push` | POST | 배포 푸시 — HTML 조립 후 운영 서버 전송 |
+| `/api/deploy/receive` | POST | 배포 수신 — HTML 파일 저장 (운영 서버) |
+| `/api/deploy/history` | GET | 배포 이력 조회 |
+
+### 2.5 스케줄러·배치 (`/api/scheduler/*`, `/api/batch/*`)
+
+| 엔드포인트 | 메서드 | 역할 |
+|-----------|--------|------|
+| `/api/scheduler/expire` | POST | 만료 페이지 일괄 처리 (외부 cron → `x-scheduler-token` 인증) |
+| `/api/batch/execute` | POST | Spider Admin BatchExecService 연동 — 만료 처리 + `FWK_BATCH_HIS` 이력 기록 |
+
+### 2.6 추적·통계 (`/api/track/*`)
+
+| 엔드포인트 | 메서드 | 역할 |
+|-----------|--------|------|
+| `/api/track/view` | POST | 페이지뷰 추적 |
+| `/api/track/click` | POST | 클릭 추적 |
+| `/api/track/stats` | GET | 통계 조회 |
+
+### 2.7 공통 코드·컴포넌트 (`/api/codes`, `/api/components`)
+
+| 엔드포인트 | 메서드 | 역할 |
+|-----------|--------|------|
+| `/api/codes` | GET | FWK 공통 코드 목록 조회 |
+| `/api/components` | GET | 등록된 컴포넌트 목록 조회 |
+
+### 2.8 인증·관리 (`/api/auth/*`, `/api/cms-admin/*`)
+
+| 엔드포인트 | 메서드 | 역할 |
+|-----------|--------|------|
+| `/api/auth/approvers` | GET | 승인자 목록 조회 |
+| `/api/cms-admin/asset-categories` | GET | 에셋 업무 카테고리 코드 조회 (FWK_CODE 연동) |
+
+### 2.9 AI 텍스트 생성
 
 | 엔드포인트 | 메서드 | 역할 |
 |-----------|--------|------|
@@ -67,7 +118,7 @@ App Router의 핵심 개념
 | `/api/openai` | POST | OpenAI API 프록시 |
 | `/api/openai/stream` | POST | OpenAI 스트리밍 |
 
-### 2.4 AI 이미지 생성 (`/api/fal/*`)
+### 2.10 AI 이미지 생성 (`/api/fal/*`)
 
 | 엔드포인트 | 메서드 | 역할 |
 |-----------|--------|------|
@@ -76,7 +127,7 @@ App Router의 핵심 개념
 | `/api/fal/result` | POST | 완료된 이미지 결과 조회 + 로컬 저장 |
 | `/api/fal/cleanup` | POST | 임시 데이터 정리 |
 
-### 2.5 금융 데이터 (플레이스홀더)
+### 2.11 금융 데이터 (플레이스홀더)
 
 | 엔드포인트 | 메서드 | 역할 | 캐시 |
 |-----------|--------|------|------|
@@ -84,6 +135,12 @@ App Router의 핵심 개념
 | `/api/branches` | GET | 영업점/ATM 위치 | 1시간 |
 
 > 현재 플레이스홀더 데이터. 프로덕션에서는 실제 API(한국수출입은행 등) 연동 필요.
+
+### 2.12 기타
+
+| 엔드포인트 | 메서드 | 역할 |
+|-----------|--------|------|
+| `/api/health` | GET | 헬스 체크 |
 
 ---
 
@@ -96,13 +153,7 @@ App Router의 핵심 개념
 sendCommandUrl: '/api/openrouter'
 sendCommandStreamUrl: '/api/openrouter/stream'
 systemModel: 'openai/gpt-4o-mini'
-
-// 비활성 (주석 처리): OpenAI
-// sendCommandUrl: '/api/openai'
-// sendCommandStreamUrl: '/api/openai/stream'
 ```
-
-전환 방법: `EditClient.tsx`에서 두 블록의 주석을 토글
 
 ### 3.2 사용 가능한 모델 목록
 
@@ -127,45 +178,33 @@ systemModel: 'openai/gpt-4o-mini'
 
 ### 4.1 페이지 콘텐츠 (Oracle DB)
 
-```sql
--- 테이블: SPW_CMS_PAGE
--- 주요 컬럼: PAGE_ID, USER_ID, PAGE_NM, FILE_PATH, STATUS, UPDATED_AT
-```
-
+- 테이블: `SPW_CMS_PAGE` — 주요 컬럼: PAGE_ID, PAGE_HTML(CLOB), FILE_PATH, APPROVE_STATE, IS_PUBLIC, EXPIRED_DATE
 - 페이지마다 DB에 독립 레코드
+- 승인 시 `SPW_CMS_PAGE_HISTORY`에 버전 스냅샷 적재
 - `src/db/repository/page.repository.ts` — CRUD 추상화 레이어
-- `src/app/api/builder/save/route.ts` → `updatePage` / `createPage`
-- `src/app/api/builder/load/route.ts` → `getPageById` + `getLatestHistory`
 
 ### 4.2 업로드 파일 (로컬 저장)
-
-```
-저장 위치: public/uploads/{path}/
-정적 서빙: /uploads/{path}/filename
-최대 크기: 100MB
-```
 
 **에셋(Asset) 저장 방식**
 
 | 영역 | 저장 | 설명 |
 |------|------|------|
-| **에셋 파일** | `ASSET_UPLOAD_DIR` (기본 `public/uploads/`) | 업로드 이미지·파일을 파일 시스템에 저장 |
-| **에셋 메타데이터** | Oracle DB (`SPW_CMS_ASSET`) | 파일명, 경로, MIME 타입, 생성자 등 |
+| **미승인 에셋 파일** | `ASSET_UPLOAD_DIR` (기본 `public/uploads/`) | CMS(:3000)에서 업로드, 결재 전 파일 |
+| **승인 완료 에셋 파일** | `DEPLOYED_UPLOAD_DIR/img/` (기본 `public/deployed/img/`) | 승인 후 `/api/assets/[assetId]/deploy`로 복사 |
+| **에셋 메타데이터** | Oracle DB (`SPW_CMS_ASSET`) | 파일명, 경로, MIME 타입, ASSET_STATE 등 |
 | **에셋 서빙** | nginx `/static/` 정적 서빙 | 운영 환경에서 `/data/uploads/`를 바인드 마운트 |
 
-> 금융권에서 "에셋"은 법무·브랜드 팀 승인을 거친 이미지, 아이콘, 로고 등 공식 파일을 의미한다.
-> **승인 프로세스는 페이지 단위**로 적용한다.
+> 승인 프로세스는 **페이지 단위** 및 **에셋 단위** 모두 적용. 에셋은 APPROVED 상태 검증 후 파일 복사.
 
-### 4.3 탭(페이지) 목록 (Oracle DB)
+### 4.3 배포 파일
 
-- 에디터 탭 목록은 `localStorage`가 아닌 DB에서 로드 (bug/#60 수정)
-- 탭 추가 시 `USER_ID` 기반 `PAGE_ID` 자동 생성
+- 배포 시 `deploy/push` → `deploy/receive` 흐름으로 완성 HTML을 운영 서버에 전송
+- 운영 서버에서 `public/deployed/{pageId}.html`로 저장
+- 배포 이력은 `FWK_CMS_FILE_SEND_HIS` 테이블에 기록 (`INSTANCE_ID + FILE_ID` 복합 PK)
 
----
+### 4.4 아키텍처 결정 기록 (ADR)
 
-## 4.4 아키텍처 결정 기록 (ADR)
-
-### ADR-0320: 에셋 DB 확장 계획 취소 (2026-03-20)
+#### ADR-0320: 에셋 DB 확장 계획 취소 (2026-03-20)
 
 **결정**: 에셋(이미지·파일)을 별도 DB 테이블로 관리하는 계획을 취소한다.
 
@@ -177,7 +216,7 @@ systemModel: 'openai/gpt-4o-mini'
 
 **확정된 방향**:
 1. 에셋은 로컬 저장 유지 (`public/uploads/`)
-2. 승인 프로세스는 **페이지 단위**만 적용 (에셋 단위 승인 없음)
+2. 승인 프로세스는 **페이지 단위** + **에셋 단위** 모두 적용
 3. 컴포넌트는 HTML 형태 + 로컬 경로 에셋 그대로 유지
 4. 정적 파일 동기화는 GitHub으로 관리, 누락 파일은 `alt` 텍스트로 대처
 
@@ -185,13 +224,78 @@ systemModel: 'openai/gpt-4o-mini'
 
 ## 5. 환경변수 (.env)
 
+### Oracle DB (필수)
+
 ```bash
-OPENROUTER_API_KEY=    # AI 텍스트 생성 (기본)
-OPENAI_API_KEY=        # AI 텍스트 생성 (대안)
+ORACLE_USER=           # DB 계정
+ORACLE_PASSWORD=       # DB 비밀번호
+ORACLE_HOST=           # DB 호스트
+ORACLE_PORT=           # DB 포트 (기본: 1521)
+ORACLE_SERVICE=        # DB 서비스명
+ORACLE_SCHEMA=         # DB 스키마
+ORACLE_POOL_MAX=       # 커넥션 풀 최대 크기 (기본: 3 — 공유 XE 세션 제한 대응)
+```
+
+### 서버 운영
+
+```bash
+SERVER_MODE=           # cms(:3000) / operation(:3001) 동작 분기 (기본: cms)
+CMS_INSTANCE_ID=       # 배포 push 시 자기 인스턴스 ID (기본: CMS-01)
+CMS_BASE_URL=          # CMS 서버 공개 URL — 배포 HTML 에셋 경로 기준 (예: http://localhost:3000)
+NEXT_PUBLIC_CMS_BASE_PATH=  # Next.js basePath (기본: /cms)
+```
+
+### 보안
+
+```bash
+JWT_SECRET=            # Spider Admin JWT 서명 키 (CMS가 검증에 사용)
+DEPLOY_SECRET=         # Spider Admin → CMS, CMS → 운영 서버 API 인증 토큰
+SCHEDULER_SECRET=      # 외부 cron → /api/scheduler/expire 인증 토큰
+AUTH_BYPASS=           # true 설정 시 인증 우회 (개발·테스트 전용)
+```
+
+### 에셋 저장소
+
+```bash
+ASSET_UPLOAD_DIR=      # 미승인 파일 저장 경로 (기본: public/uploads)
+ASSET_BASE_URL=        # 미승인 파일 URL prefix (기본: /uploads)
+DEPLOYED_UPLOAD_DIR=   # 승인 완료 파일 저장 경로 (기본: public/deployed)
+DEPLOYED_BASE_URL=     # 승인 완료 파일 URL prefix (기본: /deployed/static)
+DEPLOYED_IMG_SUBDIR=   # 승인 이미지 서브 디렉토리 (기본: img)
+```
+
+### CORS·트래커
+
+```bash
+CORS_ALLOWED_ORIGINS=  # CMS API 허용 오리진 목록 (콤마 구분)
+TRACKER_CORS_ORIGIN=   # 배포 페이지 트래커 API 허용 오리진 (기본: *)
+```
+
+### 스케줄러
+
+```bash
+ENABLE_INTERNAL_SCHEDULER=  # 내장 node-cron 활성화 여부 (기본: true)
+                             # 다중 인스턴스 환경에서는 하나만 true로 설정
+SCHEDULER_CRON=             # cron 표현식 (기본: 0 0 * * * — 매일 자정)
+```
+
+### AI 프로바이더 (선택)
+
+```bash
+OPENROUTER_API_KEY=    # AI 텍스트 생성 (기본 프로바이더)
+OPENAI_API_KEY=        # AI 텍스트 생성 (대안 프로바이더)
 FAL_API_KEY=           # AI 이미지 생성 (fal.ai)
 GEMINI_API_KEY=        # Google GenAI (웹 버전)
-ASSET_UPLOAD_DIR=      # 업로드 파일 저장 경로 (기본: public/uploads)
-ASSET_BASE_URL=        # 업로드 파일 URL prefix (기본: /uploads)
+```
+
+### 브랜드·git
+
+```bash
+BANK_BRAND=            # 금융사 브랜드 테마 (IBK / HANA / KB / IM)
+GIT_AUTO_COMMIT=       # 페이지 저장 시 git 자동 커밋·푸시 (기본: false)
+GIT_USER_NAME=         # git 커밋 사용자명 (기본: Springware CMS)
+GIT_USER_EMAIL=        # git 커밋 이메일 (기본: cms@springware.local)
+GIT_BRANCH=            # git 대상 브랜치 (기본: main)
 ```
 
 ---
@@ -199,36 +303,49 @@ ASSET_BASE_URL=        # 업로드 파일 URL prefix (기본: /uploads)
 ## 6. 금융 컴포넌트 목록
 
 금융 컴포넌트는 **순수 HTML 변환 완료** / **플러그인 유지** 두 종류로 구분됩니다.
+변환 완료 컴포넌트는 `data-component-id="<name>-<viewmode>"` 속성을 루트에 가지며, DB `SPW_CMS_COMPONENT.DATA`에 HTML로 저장됩니다.
 
-### 순수 HTML 변환 완료 (5개)
+### 순수 HTML 변환 완료 (21개 베이스, 각 mobile/web/responsive 변형)
 
-`data-cb-type` 플러그인 구조를 제거하고 ContentBuilder 인라인 편집이 가능한 순수 HTML로 전환됨.
-DB `SPW_CMS_COMPONENT.DATA.html`에 직접 저장되며, 루트 요소에 `data-component-id="<name>-<viewmode>"` 속성을 가짐.
-
-| 컴포넌트 ID | 한글명 | 설명 | 커스텀 편집 |
-|------------|--------|------|------------|
-| `app-header` | 상단 네비게이션 | 로고 + 햄버거 메뉴 | — |
-| `product-menu` | 퀵뱅킹 메뉴 | 아이콘 그리드 (조회·이체·카드 등) | `ProductMenuIconEditor.tsx` |
+| 컴포넌트 ID (베이스) | 한글명 | 설명 | 커스텀 편집 |
+|---------------------|--------|------|------------|
+| `app-header` | 상단 네비게이션 | 로고 + 햄버거 메뉴 헤더 | `AppHeaderBorderEditor.tsx` |
 | `auth-center` | 보안·인증센터 | 공동인증서·금융인증서·OTP·보안카드 | `AuthCenterIconEditor.tsx` |
+| `benefit-card` | 혜택 요약 카드 | 아이콘 + 제목 + 설명 카드 목록 | `BenefitCardEditor.tsx` |
+| `branch-locator` | 영업점/ATM 위치 | 지도 영역 + 바텀시트 영업점 목록 | `BranchLocatorEditor.tsx` |
+| `event-banner` | 이벤트 배너 | 슬라이드 배너 | `EventBannerEditor.tsx` |
+| `finance-calendar` | 금융 달력 | 금융 일정 달력 | `FinanceCalendarEditor.tsx` |
+| `flex-list` | 유연 리스트 | 커스텀 항목 리스트 | `FlexListEditor.tsx` |
+| `info-accordion` | 정보 아코디언 | 접기/펼치기 FAQ 형태 | `InfoAccordionEditor.tsx` |
+| `info-card-slide` | 정보 카드 슬라이드 | 좌우 스와이프 정보 카드 | `InfoCardSlideEditor.tsx` |
+| `loan-status` | 대출 현황 | 대출 잔액·상환 현황 | — |
+| `media-video` | 미디어 | YouTube URL 임베드 | `MediaVideoEditor.tsx` |
+| `menu-tab-grid` | 메뉴 탭 그리드 | 탭 전환 메뉴 그리드 | `MenuTabGridEditor.tsx` |
+| `mydata-asset` | 마이데이터 자산 | 자산 현황 카드 | `MyDataAssetEditor.tsx` |
+| `point-reward` | 포인트·리워드 | 포인트 현황 및 혜택 | — |
+| `popup-banner` | 팝업 배너 | 레이어 팝업 배너 | `PopupBannerEditor.tsx` |
+| `product-gallery` | 금융 상품 갤러리 | 예금·적금·대출 카드 슬라이드 | — |
+| `product-menu` | 퀵뱅킹 메뉴 | 아이콘 그리드 (조회·이체·카드 등) | `ProductMenuIconEditor.tsx` |
+| `promo-banner` | 홍보 배너 | 슬라이드 프로모션 배너 | — |
 | `site-footer` | 사이트 푸터 | 약관·연락처·TOP 버튼 | `SiteFooterSelectEditor.tsx` |
-| `media-video` | 미디어 | 유튜브 임베드 | `MediaVideoEditor.tsx` |
+| `status-card` | 상태 카드 | 상품 상태 요약 카드 | `StatusCardEditor.tsx` |
+| `sticky-floating-bar` | 하단 고정 바 | 하단 고정 CTA 버튼 영역 | — |
 
-### 플러그인 유지 (5개)
+> 각 컴포넌트는 `-mobile` / `-web` / `-responsive` 변형을 가짐 (예: `benefit-card-mobile`, `benefit-card-web`, `benefit-card-responsive`).
+
+### 플러그인 유지 (2개)
 
 JS 런타임 의존성으로 인해 플러그인 구조(`data-cb-type`)를 유지.
 `public/assets/plugins/{name}/index.js + style.css` 형식으로 각각 존재. 사용 시 lazy-load.
 
 | 플러그인 ID | 한글명 | 설명 | 유지 이유 |
 |------------|--------|------|----------|
-| `product-gallery` | 금융 상품 갤러리 | 예금/적금/대출 카드 | 변환 작업 진행 중 |
-| `promo-banner` | 홍보 배너 | 슬라이드 배너 | 변환 작업 진행 중 |
 | `exchange-board` | 환율 및 금융 지수 | USD·EUR·JPY·CNY 실시간 환율 | JS API fetch 의존 |
-| `branch-locator` | 영업점/ATM 위치 | 지도 + 바텀시트 영업점 목록 | JS 지도 렌더링 의존 |
 | `loan-calculator` | 금융 계산기 | 대출·예금·적금 탭 전환 계산기 | JS 계산 로직 의존 |
 
 ### 일반 플러그인 (43개+)
 
-logo-loop, click-counter, card-list, accordion, hero-animation, animated-stats, timeline, before-after-slider, more-info, social-share, pendulum, browser-mockup, hero-background, cta-buttons, media-slider, media-grid, particle-constellation, vector-force, aurora-glow, simple-stats, faq, callout-box, code, video-embed, swiper-slider
+logo-loop, click-counter, card-list, accordion, hero-animation, animated-stats, timeline, before-after-slider, more-info, social-share, pendulum, browser-mockup, hero-background, cta-buttons, media-slider, media-grid, particle-constellation, vector-force, aurora-glow, simple-stats, faq, callout-box, code, video-embed, swiper-slider 등
 
 ---
 
@@ -237,11 +354,12 @@ logo-loop, click-counter, card-list, accordion, hero-animation, animated-stats, 
 | 항목 | 처리 방식 |
 |------|----------|
 | **API 키** | 서버 `.env`에만 저장, 클라이언트 미노출 |
-| **Bank ID** | `/^[a-z0-9-]{1,64}$/` 정규식 검증 |
+| **Spider Admin 인증** | JWT (`jose`) 검증 — `JWT_SECRET` 공유 |
+| **서버 간 API 인증** | `x-deploy-token` 헤더 — `DEPLOY_SECRET` 타이밍 공격 방지 비교 |
 | **파일 경로** | `..` 포함 검사 + `startsWith(baseDir)` 확인 |
 | **파일명** | 특수문자 → `_` 새니타이징 |
-| **파일 크기** | 100MB 제한 |
-| **에러 응답** | 민감 정보 미노출 |
+| **CORS** | `src/middleware.ts` — `CORS_ALLOWED_ORIGINS` 기반 오리진 허용 |
+| **에러 응답** | 민감 정보 미노출 (`getErrorMessage` 유틸 사용) |
 
 ---
 
@@ -257,6 +375,8 @@ ContentBuilder 라이브러리 규약으로 일부 API는 HTTP 200에 body.error
 { error: "메시지" }                  // HTTP 400 / 500
 ```
 
+`src/lib/api-response.ts` — `successResponse`, `errorResponse`, `contentBuilderErrorResponse`, `getErrorMessage` 제공. 모든 route.ts에서 `Response.json()` / `NextResponse.json()` 직접 사용 금지.
+
 ---
 
 ## 9. 주요 컴포넌트
@@ -264,31 +384,38 @@ ContentBuilder 라이브러리 규약으로 일부 API는 HTTP 200에 body.error
 ### EditClient.tsx
 - ContentBuilder / ContentBuilderRuntime 인스턴스 관리
 - 탭(페이지) 관리: 추가·삭제·DB 저장 (`/api/builder/pages`)
-- 블록 순서 변경 패널 (드래그앤드롭)
-- 금융 컴포넌트 우측 패널
-- 저장 / 미리보기 / HTML 보기
+- 금융 컴포넌트 우측 패널 (`ComponentPanel.tsx`)
+- 저장 / 미리보기 / HTML 보기 하단 버튼
 - `#divLinkTool` 커스텀 버튼 주입 (변환된 컴포넌트용 커스텀 편집 진입점)
-
-### FileBrowser.tsx
-- 파일/폴더 탐색 (트리 + 카드 뷰)
-- 드래그앤드롭 업로드, 다중 삭제, 폴더 생성
-- 에디터와 `postMessage` 통신 (`ASSET_SELECTED` 이벤트)
+- AI 설정: OpenRouter 단일 사용 (`/api/openrouter`)
 
 ### ViewClient.tsx
 - 저장된 HTML을 `dangerouslySetInnerHTML`로 렌더링
 - ContentBuilderRuntime으로 플러그인 활성화
+- 금융 web/mobile/responsive 변형별 레이아웃 직접 초기화 (inline script 재실행 포함)
+- 반응형 미리보기: 모바일/태블릿/데스크탑 프리셋 툴바
+
+### FileBrowser (파일 브라우저)
+- `/api/manage/files`, `/api/manage/folders` 기반
+- 승인된 이미지 선택·삽입 모달 (에디터 연동)
 
 ---
 
 ## 10. 프로덕션 체크리스트
 
-- [x] 페이지 콘텐츠 → Oracle DB 전환 (완료)
-- [x] 탭 목록 → DB 저장 전환 (완료)
-- [ ] `public/uploads/` → S3/CDN 전환
+- [x] 페이지 콘텐츠 → Oracle DB 전환
+- [x] 탭 목록 → DB 저장 전환
+- [x] 인증/권한 레이어 → Spider Admin JWT 연동
+- [x] 페이지 승인 프로세스 → approve / approve-request / reject
+- [x] 이미지 승인 + 파일 이동 → `/api/assets/[assetId]/deploy`
+- [x] 파일 브라우저 UI → `/api/manage/files·folders`
+- [x] 페이지뷰·클릭 추적 → `/api/track`
+- [x] 내장 스케줄러 → node-cron 기반 만료 처리
+- [x] Spider Admin Batch 연동 → `/api/batch/execute`
+- [x] CORS 미들웨어 → `src/middleware.ts`
 - [ ] `/api/exchange` 실제 환율 API 연동
 - [ ] `/api/branches` 실제 지점 DB 연동
-- [ ] 인증/권한 레이어 추가 (현재 없음)
-- [ ] 페이지 승인 프로세스 구현
+- [ ] `public/uploads/` → S3/CDN 전환
 - [ ] FAL AI S3 저장 활성화
-- [ ] 로깅 및 모니터링 구성
 - [ ] HTTPS 설정
+- [ ] 로깅 및 모니터링 구성

--- a/docs/reference/워크플로-분석.md
+++ b/docs/reference/워크플로-분석.md
@@ -1,6 +1,6 @@
 # 전체 워크플로 분석 — 최초 페이지 제작 ~ 대고객 배포
 
-> 요구사항 3차 확정 (2026-04-16) 기준으로 정리한 문서입니다.
+> 최종 갱신: 2026-04-23
 
 ---
 
@@ -153,50 +153,58 @@ Spider Admin에서 결재자가 승인 완료
 
 ```
 Spider Admin (승인 UI)
-  → POST /api/builder/pages/{id}/approve   (CMS API 호출)
-  → POST /api/deploy/push                  (배포 트리거)
+  → POST /cms/api/builder/pages/{id}/approve-request  ← CMS API (승인 요청)
+  → POST /cms/api/builder/pages/{id}/approve          ← CMS API (승인 처리 + 이미지 파일 복사)
+  → POST /cms/api/builder/pages/{id}/reject           ← CMS API (반려)
+  → POST /cms/api/deploy/push                         ← CMS API (배포 트리거)
 ```
 
-- 승인 비즈니스 로직(DB UPDATE, 배포)은 CMS에 이미 구현되어 있음
+- 승인 비즈니스 로직(DB UPDATE, 파일 복사, 배포)은 CMS에 이미 구현되어 있음
 - Spider Admin은 UI만 제공하고, CMS API를 호출하여 처리
-- CMS 자체의 관리자 화면(승인 목록 등)은 Spider Admin으로 이식
+- CMS 자체의 관리자 화면(승인 목록 등)은 Spider Admin으로 이식 예정
 
 ---
 
-## 현재 구현 상태 vs 요구사항 (2026-04-17 기준)
+## 현재 구현 상태 vs 요구사항 (2026-04-23 기준)
 
 ### 구현 완료
 
 | 항목 | 현재 상태 |
 |---|---|
-| 서버 2대 분리 (:3000/:3001) | docker-compose-prod.yml |
+| 서버 2대 분리 (:3000/:3001) | `docker-compose-prod.yml` |
 | Docker 볼륨 분리 | `/data/uploads`(:3000 쓰기) / `/data/uploads:ro`(:3001 읽기) / `/data/deployed`(:3001 배포) |
 | nginx 리버스 프록시 | port 80 `/cms`→:3000, port 8080 `/cms`→:3001, `/static/`→`/data/uploads/`, `/deployed/static/`→`/data/deployed/img/` |
 | 이미지 물리 파일 저장 | `ASSET_UPLOAD_DIR`에 파일 저장 |
-| DB 메타데이터 관리 | SPW_CMS_ASSET 테이블 |
+| DB 메타데이터 관리 | `SPW_CMS_ASSET` 테이블 |
 | 페이지 승인 API | approve / approve-request / reject |
-| 배포 API | deploy/push, deploy/receive |
+| 배포 API | `deploy/push`, `deploy/receive` |
 | 클라우드 배포 | NHN Cloud + GitHub Actions |
 | Admin 인증 연동 | `fetchJavaAdminApi('/api/auth/me')` |
 | 역할 기반 권한 | cms_admin / cms_user |
 | SERVER_MODE 환경변수 | cms(:3000) / operation(:3001) 동작 분기 — operation 모드 이미지 업로드 차단 |
 | V6 DDL 적용 | PAGE_TYPE(PAGE/TEMPLATE), ASSET_STATE(WORK/PENDING/APPROVED/REJECTED) DB 반영 완료 |
 | AUTH_BYPASS 관리자 우회 | `/dev/admin` → 관리자 모드, `/dev/user` → 일반유저 모드 (로컬 개발용) |
+| 이미지 승인 프로세스 | `POST /api/builder/pages/{id}/approve` — DB 상태 변경 + `/data/uploads/` → `/data/deployed/img/` 파일 복사 |
+| 이미지 브라우저 UI | 에디터 내 파일브라우저 — `ContentBuilder fileUploader` 연동, 승인된 이미지 선택/삽입 |
+| A/B 테스트 | `/api/builder/ab` (그룹 CRUD + 승격) + `AbTestClient.tsx` |
+| 페이지뷰·클릭 추적 | `/api/track/view`, `/api/track/click`, `/api/track/stats` + `cms-tracker.js` 배포 삽입 |
+| 내장 스케줄러 | `node-cron` — `/api/scheduler/expire` 자동 호출 (만료 페이지 일괄 비활성화·배포) |
+| Spider Admin Batch 연동 | `FWK_CMS_FILE_SEND_HIS` UPSERT — 배포 이력 Spider Admin에 전달 (`file-send.repository.ts`) |
+| CORS 미들웨어 | `src/middleware.ts` — 트래커·운영 엔드포인트 CORS 허용 (`TRACKER_CORS_ORIGIN` 환경변수) |
+| 에셋 업무 카테고리 | `ASSET_CATEGORY` DB 필드 + API 반영 — 에셋 목록 카테고리별 필터링 |
 
 ### 미구현
 
-| 항목 | 설명 | 비고 |
-|---|---|---|
-| 이미지 승인 프로세스 | 승인 API + 파일 복사(`/data/uploads/` → `/data/deployed/img/`) | DDL 적용 완료 |
-| 이미지 브라우저 UI | 에디터에서 승인된 이미지 선택/삽입 모달 | 파일브라우저 복원·개선 |
-| 템플릿 시스템 | 템플릿 CRUD + 카테고리 분류 + 승인 + 목록 조회 | DDL 적용 완료 |
-| 템플릿 → 페이지 생성 | 승인된 템플릿 선택 → PAGE_HTML 복사 → 새 PAGE INSERT | TEMPLATE_ID로 참조 추적 |
-| ASSET_PAGE_MAP 적재 | 승인 시 HTML 파싱 → 사용 이미지 추출 → MAP INSERT | 테이블 존재, 로직 미구현 |
-| 역할 세분화 | 현재 2단계(admin/user) → 현업 관리자/결재자/현업 제작자 | Spider Admin 연동 |
-| :3001 편집 환경 | 현재 :3000에서만 편집 → :3001에서도 편집 가능해야 함 | 같은 소스, 설정 분기 |
-| CMS 관리자 화면 → Spider 이식 | CMS 승인 관리 UI를 Spider Admin으로 이식 | Spider 프로젝트 작업 |
-| 서브도메인 매핑 | 현재 경로 기반 `/static/` → `img.mydomain.com` | 도메인 설정 필요 |
-| 다단계 결재 | 현재 단일 승인 → 최소 3단계 | 후순위 |
+| 항목 | 설명 | 담당 | 비고 |
+|---|---|---|---|
+| 템플릿 시스템 | 템플릿 CRUD + 카테고리 분류 + 승인 + 목록 조회 | CMS | DDL 적용 완료 |
+| 템플릿 → 페이지 생성 | 승인된 템플릿 선택 → PAGE_HTML 복사 → 새 PAGE INSERT | CMS | TEMPLATE_ID로 참조 추적 |
+| ASSET_PAGE_MAP 적재 | 승인 시 HTML 파싱 → 사용 이미지 추출 → MAP INSERT | CMS | 테이블 존재, 로직 미구현 |
+| :3001 편집 환경 | 현재 :3000에서만 편집 → :3001에서도 편집 가능해야 함 | CMS | 같은 소스, 설정 분기 |
+| 역할 세분화 | 현재 2단계(admin/user) → 현업 관리자/결재자/현업 제작자 | Spider Admin | Spider Admin 연동 |
+| CMS 관리자 화면 → Spider 이식 | CMS 승인 관리 UI를 Spider Admin으로 이식 | Spider Admin | Spider 프로젝트 작업 |
+| 다단계 결재 | 현재 단일 승인 → 최소 3단계 | Spider Admin | 후순위 |
+| 서브도메인 매핑 | 현재 경로 기반 `/static/` → `img.mydomain.com` | 인프라 | 도메인 설정 필요 |
 
 ---
 


### PR DESCRIPTION
## Summary

- `docs/reference/기술-개요.md` 전체 재작성 — 현재 구현 기준으로 기술 스택, API 엔드포인트, 환경변수, 금융 컴포넌트 목록 최신화
- `docs/reference/워크플로-분석.md` 업데이트 — 구현 완료 항목 이동, 미구현 항목 담당 컬럼 추가, 승인 처리 구조 API 경로 갱신

## 변경 세부 내용

### 기술-개요.md
- 기술 스택 3개 추가: `oracledb`, `node-cron`, `jose`
- API 엔드포인트 30개+ 전체 문서화 (12개 섹션)
- 환경변수 30개+ 7개 카테고리로 정리
- 금융 컴포넌트 21종 × mobile/web/responsive 변형 표
- 보안 항목 및 운영 체크리스트 10개 완성

### 워크플로-분석.md
- 구현 완료 항목 8개 이동: 이미지 승인 프로세스, 이미지 브라우저 UI, A/B 테스트, 페이지뷰·클릭 추적, 내장 스케줄러, Spider Admin Batch 연동, CORS 미들웨어, 에셋 업무 카테고리
- 미구현 테이블에 **담당** 컬럼 추가 (CMS / Spider Admin / 인프라 구분)
- 승인 처리 구조 API 경로 갱신 (`/cms/api/...` basePath 반영 + `← CMS API` 명시)
- 기준일 2026-04-23 반영

## Closes
closes #71

🤖 Generated with [Claude Code](https://claude.ai/claude-code)