### PR TITLE
fix #69 : /cms/..에서 새페이지 안만들어지는 오류 해결

### DIFF
--- a/src/app/api/builder/save/route.ts
+++ b/src/app/api/builder/save/route.ts
@@ -6,6 +6,7 @@ import { updatePage, createPage, getPageById, resetApproveStateToWork } from '@/
 import { canAccessCmsEdit, canManageCmsPage, getCurrentUser } from '@/lib/current-user';
 import { isValidBankId, isPageExpired } from '@/lib/validators';
 import { successResponse, contentBuilderErrorResponse, getErrorMessage } from '@/lib/api-response';
+import { nextApi } from '@/lib/api-url';
 
 // 페이지 저장: DB PAGE_HTML에 HTML 직접 저장
 async function savePage(
@@ -15,6 +16,7 @@ async function savePage(
     viewMode?: string,
     thumbnail?: string,
     templateId?: string,
+    skipExistingLookup = false,
 ): Promise<void> {
     const currentUser = await getCurrentUser();
     if (!canAccessCmsEdit(currentUser)) {
@@ -23,7 +25,7 @@ async function savePage(
     const { userId, userName } = currentUser;
 
     // 1. 기존 페이지 확인 + 만료 체크
-    const existing = await getPageById(bank);
+    const existing = skipExistingLookup ? null : await getPageById(bank);
     if (existing && isPageExpired(existing.IS_PUBLIC, existing.EXPIRED_DATE)) {
         throw new Error('만료된 페이지는 수정할 수 없습니다.');
     }
@@ -46,11 +48,20 @@ async function savePage(
         // 3. 승인/반려 상태이면 WORK로 전환 (재승인 플로우)
         await resetApproveStateToWork(bank, userId);
     } else {
+        let pageHtml = html;
+        if (templateId) {
+            const template = await getPageById(templateId);
+            if (!template || template.PAGE_TYPE !== 'TEMPLATE') {
+                throw new Error('유효하지 않은 템플릿입니다.');
+            }
+            pageHtml = template.PAGE_HTML ?? '';
+        }
+
         await createPage({
             pageId: bank,
             pageName: pageName ?? bank,
             viewMode: (viewMode as 'mobile' | 'web' | 'responsive') ?? 'mobile',
-            pageHtml: html,
+            pageHtml,
             thumbnail,
             createUserId: userId,
             createUserName: userName,
@@ -65,7 +76,8 @@ export async function POST(req: NextRequest) {
         const { html, pageName, viewMode, thumbnail, templateId } = body;
 
         // bank 미전달 또는 유효하지 않으면 서버에서 UUID 생성 (신규 페이지)
-        const bank = isValidBankId(body.bank) ? body.bank : crypto.randomUUID();
+        const hasValidBank = isValidBankId(body.bank);
+        const bank = hasValidBank ? body.bank : crypto.randomUUID();
 
         if (html === undefined || html === null) {
             return contentBuilderErrorResponse('HTML 콘텐츠가 없습니다.');
@@ -78,9 +90,10 @@ export async function POST(req: NextRequest) {
             typeof viewMode === 'string' ? viewMode : undefined,
             typeof thumbnail === 'string' ? thumbnail : undefined,
             typeof templateId === 'string' && templateId !== 'blank' ? templateId : undefined,
+            !hasValidBank,
         );
 
-        return successResponse({ pageId: bank });
+        return successResponse({ pageId: bank, editorUrl: nextApi(`/edit?bank=${encodeURIComponent(bank)}`) });
     } catch (err: unknown) {
         console.error('페이지 저장 실패:', err);
         return contentBuilderErrorResponse(getErrorMessage(err));

--- a/src/app/api/builder/templates/route.ts
+++ b/src/app/api/builder/templates/route.ts
@@ -1,0 +1,18 @@
+import { getPageTemplateList } from '@/db/repository/page.repository';
+import { canReadCms, getCurrentUser } from '@/lib/current-user';
+import { errorResponse, getErrorMessage, successResponse } from '@/lib/api-response';
+
+export async function GET() {
+    try {
+        const currentUser = await getCurrentUser();
+        if (!canReadCms(currentUser)) {
+            return errorResponse('권한이 없습니다.', 403);
+        }
+
+        const templates = await getPageTemplateList();
+        return successResponse({ templates });
+    } catch (err: unknown) {
+        console.error('템플릿 목록 조회 실패:', err);
+        return errorResponse(getErrorMessage(err));
+    }
+}

--- a/src/components/dashboard/DashboardClient.tsx
+++ b/src/components/dashboard/DashboardClient.tsx
@@ -4,7 +4,7 @@
 import { useState, useEffect, useRef, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 
-import Modal from '@/components/ui/Modal';
+import CreatePageModal from '@/components/ui/CreatePageModal';
 import PageCard, { APPROVE_DEFAULT_LABELS, formatDate } from '@/components/ui/PageCard';
 import type { ViewMode, ApproveStateValue } from '@/components/ui/PageCard';
 import { nextApi } from '@/lib/api-url';
@@ -101,9 +101,6 @@ export default function DashboardClient({
 
     // 새 페이지 생성 모달
     const [showCreateModal, setShowCreateModal] = useState(false);
-    const [newPageName, setNewPageName] = useState('');
-    const [newPageViewMode, setNewPageViewMode] = useState<ViewMode>('mobile');
-    const [creating, setCreating] = useState(false);
 
     const [sortDropdownOpen, setSortDropdownOpen] = useState(false);
     const sortDropdownRef = useRef<HTMLDivElement>(null);
@@ -167,32 +164,6 @@ export default function DashboardClient({
     // 페이지 이동 → URL 반영
     function handlePageChange(page: number) {
         navigate({ page, search, sortBy });
-    }
-
-    // 새 페이지 생성
-    async function handleCreatePage() {
-        const label = newPageName.trim();
-        if (!label || creating || !canWrite) return;
-
-        setCreating(true);
-
-        try {
-            const res = await fetch(nextApi('/api/builder/save'), {
-                method: 'POST',
-                body: JSON.stringify({ html: '', pageName: label, viewMode: newPageViewMode }),
-                headers: { 'Content-Type': 'application/json' },
-            });
-            const data = await res.json();
-            if (res.ok && data.ok) {
-                window.location.href = nextApi(`/edit?bank=${data.pageId}`);
-            } else {
-                alert(data.error || '페이지 생성에 실패했습니다.');
-                setCreating(false);
-            }
-        } catch (err: unknown) {
-            console.error('페이지 생성 실패:', err);
-            setCreating(false);
-        }
     }
 
     // 승인 요청 — 낙관적 업데이트 후 API 호출
@@ -261,8 +232,6 @@ export default function DashboardClient({
 
     function handleModalClose() {
         setShowCreateModal(false);
-        setNewPageName('');
-        setNewPageViewMode('mobile');
     }
 
     const totalPages = Math.ceil(localTotalCount / PAGE_SIZE);
@@ -563,70 +532,7 @@ export default function DashboardClient({
             {rejectedTarget && <RejectedReasonModal page={rejectedTarget} onClose={() => setRejectedTarget(null)} />}
 
             {/* ── 새 페이지 생성 모달 ── */}
-            {showCreateModal && (
-                <Modal
-                    title="새 페이지 만들기"
-                    onClose={handleModalClose}
-                    showCloseButton={false}
-                    width="480px"
-                    className="p-8"
-                >
-                    <label className="block text-[13px] font-semibold text-[#374151] mb-1.5">페이지 이름</label>
-                    <input
-                        autoFocus
-                        value={newPageName}
-                        onChange={(e) => setNewPageName(e.target.value)}
-                        onKeyDown={(e) => {
-                            if (e.key === 'Enter' && newPageName.trim()) handleCreatePage();
-                        }}
-                        placeholder="예: 메인 페이지"
-                        className="w-full box-border px-[14px] py-2.5 rounded-lg border border-[#d1d5db] text-sm mb-5 outline-none"
-                    />
-
-                    <label className="block text-[13px] font-semibold text-[#374151] mb-2">화면 유형</label>
-                    <div className="flex gap-2.5 mb-7">
-                        {(['mobile', 'web', 'responsive'] as ViewMode[]).map((vm) => {
-                            const icon = vm === 'mobile' ? '📱' : vm === 'web' ? '🖥️' : '🔄';
-                            const vmLabel = vm === 'mobile' ? '모바일' : vm === 'web' ? '웹' : '반응형';
-                            const selected = newPageViewMode === vm;
-                            return (
-                                <button
-                                    key={vm}
-                                    onClick={() => setNewPageViewMode(vm)}
-                                    className={`flex-1 py-2.5 px-1.5 rounded-lg border-2 text-[13px] font-semibold cursor-pointer flex flex-col items-center gap-1 ${
-                                        selected
-                                            ? 'border-[#0046A4] bg-[#f0f4ff] text-[#0046A4]'
-                                            : 'border-[#e5e7eb] bg-white text-[#6b7280]'
-                                    }`}
-                                >
-                                    <span className="text-[20px]">{icon}</span>
-                                    {vmLabel}
-                                </button>
-                            );
-                        })}
-                    </div>
-
-                    <div className="flex justify-end gap-2">
-                        <button
-                            onClick={handleModalClose}
-                            className="px-5 py-2.5 rounded-lg border border-[#e5e7eb] bg-white text-[#374151] text-sm cursor-pointer"
-                        >
-                            취소
-                        </button>
-                        <button
-                            onClick={handleCreatePage}
-                            disabled={!newPageName.trim() || creating || !canWrite}
-                            className={`px-5 py-2.5 rounded-lg border-0 text-white text-sm font-semibold ${
-                                !newPageName.trim() || creating || !canWrite
-                                    ? 'bg-[#d1d5db] cursor-not-allowed'
-                                    : 'bg-[#0046A4] cursor-pointer'
-                            }`}
-                        >
-                            {creating ? '생성 중...' : '만들기'}
-                        </button>
-                    </div>
-                </Modal>
-            )}
+            {showCreateModal && <CreatePageModal onClose={handleModalClose} canWrite={canWrite} />}
         </div>
     );
 }

--- a/src/components/edit/EditClient.tsx
+++ b/src/components/edit/EditClient.tsx
@@ -29,6 +29,7 @@ import StatusCardEditor from '@/components/edit/StatusCardEditor';
 import MyDataAssetEditor from '@/components/edit/MyDataAssetEditor';
 import FinanceCalendarEditor from '@/components/edit/FinanceCalendarEditor';
 import EventBannerEditor from '@/components/edit/EventBannerEditor';
+import CreatePageModal from '@/components/ui/CreatePageModal';
 import Toast from '@/components/ui/Toast';
 import type { FinanceComponent } from '@/data/finance-component-data';
 import { type BrandTheme } from '@/data/brand-themes';
@@ -176,25 +177,12 @@ const PANEL_WIDTH_OPEN = 264;
 
 // ── 뷰 모드 ──────────────────────────────────────────────────────────────
 type ViewMode = 'mobile' | 'web' | 'responsive';
-type PageTemplateId = 'blank';
 
 const VIEW_MODE_CONFIG: Record<ViewMode, { label: string; maxWidth: string; icon: string }> = {
     mobile: { label: '모바일', maxWidth: '390px', icon: '📱' },
     web: { label: '웹', maxWidth: '1280px', icon: '🖥️' },
     responsive: { label: '반응형', maxWidth: '100%', icon: '🔄' },
 };
-
-const PAGE_TEMPLATE_CONFIG: Record<PageTemplateId, { label: string; description: string }> = {
-    blank: {
-        label: '빈 페이지',
-        description: '아무 컴포넌트도 없는 빈 화면에서 시작합니다.',
-    },
-};
-
-const PAGE_TEMPLATE_OPTIONS = Object.entries(PAGE_TEMPLATE_CONFIG).map(([id, template]) => ({
-    id: id as PageTemplateId,
-    ...template,
-}));
 
 function roundMs(value: number) {
     return Math.round(value * 10) / 10;
@@ -315,12 +303,6 @@ export default function EditClient({
     const [tabsLoading, setTabsLoading] = useState(true);
     // 탭 추가 인라인 입력 표시 여부
     const [showAddTab, setShowAddTab] = useState(false);
-    // 탭 이름 입력값
-    const [newTabName, setNewTabName] = useState('');
-    // 새 탭 생성 시 선택할 뷰 모드
-    const [newTabViewMode, setNewTabViewMode] = useState<ViewMode>('mobile');
-    const [newTabTemplateId, setNewTabTemplateId] = useState<PageTemplateId>('blank');
-    const [newTabTemplateOpen, setNewTabTemplateOpen] = useState(true);
 
     // product-menu 아이콘 편집 모달
     const [productMenuBlock, setProductMenuBlock] = useState<HTMLElement | null>(null);
@@ -2361,47 +2343,6 @@ export default function EditClient({
     }
 
     // ── 탭 추가 ──────────────────────────────────────────────────────────
-    async function handleAddTab() {
-        const label = newTabName.trim();
-        if (!label) return;
-        if (!canWrite) return;
-        const id = crypto.randomUUID();
-        const selectedViewMode = newTabViewMode;
-        const selectedTemplateId = newTabTemplateId;
-
-        setShowAddTab(false);
-        setNewTabName('');
-        setNewTabViewMode('mobile');
-        setNewTabTemplateId('blank');
-        setNewTabTemplateOpen(true);
-
-        const defaultHtml = selectedTemplateId === 'blank' ? '' : '';
-
-        // DB에 페이지 생성 (pageName + viewMode 포함) → 이동
-        try {
-            const res = await fetch(nextApi('/api/builder/save'), {
-                method: 'POST',
-                body: JSON.stringify({
-                    html: defaultHtml,
-                    bank: id,
-                    pageName: label,
-                    viewMode: selectedViewMode,
-                    templateId: selectedTemplateId,
-                }),
-                headers: { 'Content-Type': 'application/json' },
-            });
-            const data = await res.json();
-            if (!res.ok || !data.ok || !data.pageId) {
-                alert(data.error || '페이지 생성에 실패했습니다.');
-                return;
-            }
-            window.location.href = nextApi(`/edit?bank=${data.pageId}`);
-        } catch (err: unknown) {
-            console.error('페이지 생성 실패:', err);
-            alert('페이지 생성 중 오류가 발생했습니다.');
-        }
-    }
-
     // ── 탭 닫기 ──────────────────────────────────────────────────────────
     // DB 삭제 없이 세션 탭 목록에서만 제거. 실제 삭제는 대시보드에서 수행.
     function handleCloseTab() {
@@ -2563,7 +2504,7 @@ export default function EditClient({
                         tabs.map((b) => (
                             <a
                                 key={b.id}
-                                href={`/edit?bank=${b.id}`}
+                                href={nextApi(`/edit?bank=${b.id}`)}
                                 style={{
                                     padding: '5px 14px',
                                     borderRadius: '6px',
@@ -2902,291 +2843,7 @@ export default function EditClient({
             )}
 
             {/* ── 새 페이지 추가 모달 ── */}
-            {showAddTab && (
-                <div
-                    onClick={() => {
-                        setShowAddTab(false);
-                        setNewTabName('');
-                        setNewTabViewMode('mobile');
-                        setNewTabTemplateId('blank');
-                        setNewTabTemplateOpen(true);
-                    }}
-                    style={{
-                        position: 'fixed',
-                        inset: 0,
-                        zIndex: 200,
-                        background: 'rgba(0,0,0,0.4)',
-                        backdropFilter: 'blur(2px)',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                    }}
-                >
-                    <div
-                        onClick={(e) => e.stopPropagation()}
-                        style={{
-                            background: '#ffffff',
-                            borderRadius: '20px',
-                            padding: '32px',
-                            width: '480px',
-                            maxWidth: '90vw',
-                            boxShadow: '0 24px 64px rgba(0,70,164,0.15)',
-                        }}
-                    >
-                        <h3 style={{ margin: '0 0 24px', fontSize: '18px', fontWeight: 700, color: '#111827' }}>
-                            새 페이지 만들기
-                        </h3>
-
-                        {/* 페이지 이름 */}
-                        <label
-                            style={{
-                                display: 'block',
-                                fontSize: '13px',
-                                fontWeight: 600,
-                                color: '#374151',
-                                marginBottom: '6px',
-                            }}
-                        >
-                            페이지 이름
-                        </label>
-                        <input
-                            autoFocus
-                            value={newTabName}
-                            onChange={(e) => setNewTabName(e.target.value)}
-                            onKeyDown={(e) => {
-                                if (e.key === 'Enter' && newTabName.trim()) handleAddTab();
-                                if (e.key === 'Escape') {
-                                    setShowAddTab(false);
-                                    setNewTabName('');
-                                    setNewTabViewMode('mobile');
-                                    setNewTabTemplateId('blank');
-                                    setNewTabTemplateOpen(true);
-                                }
-                            }}
-                            placeholder="예: 메인 페이지"
-                            style={{
-                                width: '100%',
-                                height: '40px',
-                                padding: '0 12px',
-                                borderRadius: '8px',
-                                border: '1px solid #d1d5db',
-                                fontSize: '14px',
-                                outline: 'none',
-                                boxSizing: 'border-box',
-                            }}
-                        />
-
-                        {/* 레이아웃 선택 */}
-                        <label
-                            style={{
-                                display: 'block',
-                                fontSize: '13px',
-                                fontWeight: 600,
-                                color: '#374151',
-                                margin: '20px 0 10px',
-                            }}
-                        >
-                            레이아웃 선택
-                        </label>
-                        <div style={{ display: 'flex', gap: '12px' }}>
-                            {(Object.keys(VIEW_MODE_CONFIG) as ViewMode[]).map((mode) => {
-                                const cfg = VIEW_MODE_CONFIG[mode];
-                                const selected = newTabViewMode === mode;
-                                const descriptions: Record<ViewMode, string> = {
-                                    mobile: '390px 고정 너비\n모바일 앱 화면에 최적화',
-                                    web: '1280px 고정 너비\n데스크톱 웹 페이지용',
-                                    responsive: '전체 너비 사용\n모든 기기에 대응',
-                                };
-                                return (
-                                    <button
-                                        key={mode}
-                                        type="button"
-                                        onClick={() => setNewTabViewMode(mode)}
-                                        style={{
-                                            flex: 1,
-                                            padding: '16px 12px',
-                                            borderRadius: '12px',
-                                            border: selected ? '2px solid #0046A4' : '2px solid #e5e7eb',
-                                            background: selected ? '#f0f4ff' : '#ffffff',
-                                            cursor: 'pointer',
-                                            textAlign: 'center',
-                                            transition: 'all 0.15s',
-                                        }}
-                                    >
-                                        <div style={{ fontSize: '32px', marginBottom: '8px' }}>{cfg.icon}</div>
-                                        <div
-                                            style={{
-                                                fontSize: '14px',
-                                                fontWeight: 700,
-                                                color: selected ? '#0046A4' : '#374151',
-                                                marginBottom: '6px',
-                                            }}
-                                        >
-                                            {cfg.label}
-                                        </div>
-                                        <div
-                                            style={{
-                                                fontSize: '11px',
-                                                color: '#6b7280',
-                                                lineHeight: 1.4,
-                                                whiteSpace: 'pre-line',
-                                            }}
-                                        >
-                                            {descriptions[mode]}
-                                        </div>
-                                    </button>
-                                );
-                            })}
-                        </div>
-
-                        <p style={{ fontSize: '11px', color: '#9ca3af', margin: '12px 0 0', lineHeight: 1.4 }}>
-                            레이아웃은 페이지 생성 후 변경할 수 없습니다.
-                        </p>
-
-                        <div style={{ marginTop: '22px' }}>
-                            <button
-                                type="button"
-                                onClick={() => setNewTabTemplateOpen((open) => !open)}
-                                style={{
-                                    width: '100%',
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'space-between',
-                                    padding: '12px 14px',
-                                    borderRadius: '8px',
-                                    border: '1px solid #e5e7eb',
-                                    background: '#ffffff',
-                                    cursor: 'pointer',
-                                }}
-                            >
-                                <span style={{ fontSize: '13px', fontWeight: 700, color: '#374151' }}>템플릿 선택</span>
-                                <span
-                                    style={{
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        gap: '8px',
-                                        fontSize: '12px',
-                                        color: '#6b7280',
-                                    }}
-                                >
-                                    <span>{PAGE_TEMPLATE_CONFIG[newTabTemplateId].label}</span>
-                                    <span
-                                        style={{
-                                            transform: newTabTemplateOpen ? 'rotate(180deg)' : 'rotate(0deg)',
-                                            transition: 'transform 0.15s',
-                                        }}
-                                    >
-                                        ▼
-                                    </span>
-                                </span>
-                            </button>
-
-                            {newTabTemplateOpen && (
-                                <div
-                                    style={{
-                                        marginTop: '8px',
-                                        display: 'flex',
-                                        flexDirection: 'column',
-                                        gap: '8px',
-                                        maxHeight: '220px',
-                                        overflowY: 'auto',
-                                        paddingRight: '4px',
-                                    }}
-                                >
-                                    {PAGE_TEMPLATE_OPTIONS.map((template) => {
-                                        const selected = newTabTemplateId === template.id;
-                                        return (
-                                            <button
-                                                key={template.id}
-                                                type="button"
-                                                onClick={() => setNewTabTemplateId(template.id)}
-                                                style={{
-                                                    display: 'flex',
-                                                    gap: '10px',
-                                                    alignItems: 'flex-start',
-                                                    width: '100%',
-                                                    padding: '12px 14px',
-                                                    borderRadius: '8px',
-                                                    border: selected ? '2px solid #0046A4' : '1px solid #e5e7eb',
-                                                    background: selected ? '#f0f4ff' : '#ffffff',
-                                                    color: '#374151',
-                                                    cursor: 'pointer',
-                                                    textAlign: 'left',
-                                                }}
-                                            >
-                                                <span
-                                                    style={{
-                                                        width: '16px',
-                                                        height: '16px',
-                                                        marginTop: '1px',
-                                                        borderRadius: '50%',
-                                                        border: selected ? '5px solid #0046A4' : '1px solid #d1d5db',
-                                                        background: '#ffffff',
-                                                        flexShrink: 0,
-                                                    }}
-                                                />
-                                                <span>
-                                                    <span
-                                                        style={{
-                                                            display: 'block',
-                                                            fontSize: '13px',
-                                                            fontWeight: 700,
-                                                            color: selected ? '#0046A4' : '#111827',
-                                                        }}
-                                                    >
-                                                        {template.label}
-                                                    </span>
-                                                    <span
-                                                        style={{
-                                                            display: 'block',
-                                                            marginTop: '3px',
-                                                            fontSize: '11px',
-                                                            lineHeight: 1.4,
-                                                            color: '#6b7280',
-                                                        }}
-                                                    >
-                                                        {template.description}
-                                                    </span>
-                                                </span>
-                                            </button>
-                                        );
-                                    })}
-                                </div>
-                            )}
-                        </div>
-
-                        {/* 하단 버튼 */}
-                        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px', marginTop: '24px' }}>
-                            <button
-                                onClick={() => {
-                                    setShowAddTab(false);
-                                    setNewTabName('');
-                                    setNewTabViewMode('mobile');
-                                    setNewTabTemplateId('blank');
-                                    setNewTabTemplateOpen(true);
-                                }}
-                                style={{ ...btnStyle, padding: '8px 20px' }}
-                            >
-                                취소
-                            </button>
-                            <button
-                                onClick={handleAddTab}
-                                disabled={!newTabName.trim()}
-                                style={{
-                                    ...btnStyle,
-                                    padding: '8px 20px',
-                                    background: newTabName.trim() ? '#0046A4' : '#93c5fd',
-                                    color: '#fff',
-                                    borderColor: newTabName.trim() ? '#0046A4' : '#93c5fd',
-                                    cursor: newTabName.trim() ? 'pointer' : 'not-allowed',
-                                }}
-                            >
-                                만들기
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            )}
+            {showAddTab && <CreatePageModal onClose={() => setShowAddTab(false)} canWrite={canWrite} />}
 
             {infoToast && <Toast message={infoToast} />}
         </>

--- a/src/components/ui/CreatePageModal.tsx
+++ b/src/components/ui/CreatePageModal.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { createCmsPage, type CmsPageViewMode } from '@/lib/cms-page-create';
+import { nextApi } from '@/lib/api-url';
+
+import Modal from './Modal';
+
+interface PageTemplateOption {
+    id: string;
+    label: string;
+    description: string;
+}
+
+const VIEW_MODE_OPTIONS: Array<{
+    id: CmsPageViewMode;
+    label: string;
+    icon: string;
+    description: string;
+}> = [
+    { id: 'mobile', label: '모바일', icon: '📱', description: '390px 고정 너비\n모바일 앱 화면에 최적화' },
+    { id: 'web', label: '웹', icon: '🖥️', description: '1280px 고정 너비\n데스크톱 웹 페이지용' },
+    { id: 'responsive', label: '반응형', icon: '🔄', description: '전체 너비 사용\n모든 기기에 대응' },
+];
+
+const BLANK_TEMPLATE: PageTemplateOption = {
+    id: 'blank',
+    label: '빈 페이지',
+    description: '아무 컴포넌트도 없는 빈 화면에서 시작합니다.',
+};
+
+export interface CreatePageModalProps {
+    onClose: () => void;
+    canWrite: boolean;
+}
+
+export default function CreatePageModal({ onClose, canWrite }: CreatePageModalProps) {
+    const [pageName, setPageName] = useState('');
+    const [viewMode, setViewMode] = useState<CmsPageViewMode>('mobile');
+    const [templateId, setTemplateId] = useState('blank');
+    const [templateOpen, setTemplateOpen] = useState(true);
+    const [templates, setTemplates] = useState<PageTemplateOption[]>([BLANK_TEMPLATE]);
+    const [templatesLoading, setTemplatesLoading] = useState(true);
+    const [templatesError, setTemplatesError] = useState<string | null>(null);
+    const [creating, setCreating] = useState(false);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        async function loadTemplates() {
+            setTemplatesLoading(true);
+            setTemplatesError(null);
+            try {
+                const res = await fetch(nextApi('/api/builder/templates'));
+                const data = await res.json();
+                if (!res.ok || !data.ok) {
+                    throw new Error(data.error || '템플릿 목록을 불러오지 못했습니다.');
+                }
+                if (cancelled) return;
+
+                const nextTemplates = Array.isArray(data.templates)
+                    ? data.templates.map((template: { pageId: string; pageName: string }) => ({
+                          id: template.pageId,
+                          label: template.pageName,
+                          description: '미리 구성된 템플릿으로 시작합니다.',
+                      }))
+                    : [];
+
+                setTemplates([BLANK_TEMPLATE, ...nextTemplates]);
+            } catch (err: unknown) {
+                if (cancelled) return;
+                setTemplates([BLANK_TEMPLATE]);
+                setTemplatesError(err instanceof Error ? err.message : '템플릿 목록을 불러오지 못했습니다.');
+            } finally {
+                if (!cancelled) {
+                    setTemplatesLoading(false);
+                }
+            }
+        }
+
+        void loadTemplates();
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const selectedTemplate = templates.find((template) => template.id === templateId) ?? BLANK_TEMPLATE;
+
+    async function handleCreate() {
+        const trimmedName = pageName.trim();
+        if (!trimmedName || creating || !canWrite) return;
+
+        setCreating(true);
+        try {
+            const created = await createCmsPage({
+                pageName: trimmedName,
+                viewMode,
+                templateId,
+            });
+            window.location.href = created.editorUrl;
+        } catch (err: unknown) {
+            console.error('페이지 생성 실패:', err);
+            alert(err instanceof Error ? err.message : '페이지 생성에 실패했습니다.');
+            setCreating(false);
+        }
+    }
+
+    return (
+        <Modal title="새 페이지 만들기" onClose={onClose} showCloseButton={false} width="480px" className="p-8">
+            <label className="block text-[13px] font-semibold text-[#374151] mb-1.5">페이지 이름</label>
+            <input
+                autoFocus
+                value={pageName}
+                onChange={(e) => setPageName(e.target.value)}
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter' && pageName.trim()) {
+                        void handleCreate();
+                    }
+                }}
+                placeholder="예: 메인 페이지"
+                className="w-full h-10 box-border px-3 rounded-lg border border-[#d1d5db] text-sm outline-none"
+            />
+
+            <label className="block text-[13px] font-semibold text-[#374151] mt-5 mb-2.5">레이아웃 선택</label>
+            <div className="flex gap-3">
+                {VIEW_MODE_OPTIONS.map((option) => {
+                    const selected = viewMode === option.id;
+                    return (
+                        <button
+                            key={option.id}
+                            type="button"
+                            onClick={() => setViewMode(option.id)}
+                            className={`flex-1 px-3 py-4 rounded-xl border-2 text-center cursor-pointer transition-all ${
+                                selected
+                                    ? 'border-[#0046A4] bg-[#f0f4ff] text-[#0046A4]'
+                                    : 'border-[#e5e7eb] bg-white text-[#374151]'
+                            }`}
+                        >
+                            <span className="block text-[32px] mb-2">{option.icon}</span>
+                            <span className="block text-sm font-bold mb-1.5">{option.label}</span>
+                            <span className="block text-[11px] leading-[1.4] text-[#6b7280] whitespace-pre-line">
+                                {option.description}
+                            </span>
+                        </button>
+                    );
+                })}
+            </div>
+
+            <p className="text-[11px] text-[#9ca3af] mt-3 mb-0 leading-[1.4]">
+                레이아웃은 페이지 생성 후 변경할 수 없습니다.
+            </p>
+
+            <div className="mt-[22px]">
+                <button
+                    type="button"
+                    onClick={() => setTemplateOpen((open) => !open)}
+                    className="w-full flex items-center justify-between px-[14px] py-3 rounded-lg border border-[#e5e7eb] bg-white cursor-pointer"
+                >
+                    <span className="text-[13px] font-bold text-[#374151]">템플릿 선택</span>
+                    <span className="flex items-center gap-2 text-xs text-[#6b7280]">
+                        <span className="max-w-[180px] overflow-hidden text-ellipsis whitespace-nowrap">
+                            {selectedTemplate.label}
+                        </span>
+                        <span
+                            className="transition-transform"
+                            style={{ transform: templateOpen ? 'rotate(180deg)' : 'rotate(0deg)' }}
+                        >
+                            ▼
+                        </span>
+                    </span>
+                </button>
+
+                {templateOpen && (
+                    <div className="mt-2 flex flex-col gap-2 max-h-[220px] overflow-y-auto pr-1">
+                        {templates.map((template) => {
+                            const selected = templateId === template.id;
+                            return (
+                                <button
+                                    key={template.id}
+                                    type="button"
+                                    onClick={() => setTemplateId(template.id)}
+                                    className={`w-full flex gap-[10px] items-start px-[14px] py-3 rounded-lg text-left cursor-pointer ${
+                                        selected
+                                            ? 'border-2 border-[#0046A4] bg-[#f0f4ff] text-[#374151]'
+                                            : 'border border-[#e5e7eb] bg-white text-[#374151]'
+                                    }`}
+                                >
+                                    <span
+                                        className="w-4 h-4 mt-[1px] rounded-full bg-white shrink-0"
+                                        style={{ border: selected ? '5px solid #0046A4' : '1px solid #d1d5db' }}
+                                    />
+                                    <span>
+                                        <span
+                                            className={`block text-[13px] font-bold ${
+                                                selected ? 'text-[#0046A4]' : 'text-[#111827]'
+                                            }`}
+                                        >
+                                            {template.label}
+                                        </span>
+                                        <span className="block mt-[3px] text-[11px] leading-[1.4] text-[#6b7280]">
+                                            {template.description}
+                                        </span>
+                                    </span>
+                                </button>
+                            );
+                        })}
+                    </div>
+                )}
+
+                {templatesLoading && <p className="text-xs text-[#9ca3af] mt-2 mb-0">템플릿 목록을 불러오는 중...</p>}
+                {templatesError && <p className="text-xs text-[#dc2626] mt-2 mb-0">{templatesError}</p>}
+            </div>
+
+            <div className="flex justify-end gap-2 mt-6">
+                <button
+                    onClick={onClose}
+                    className="px-5 py-2 rounded-lg border border-[#e5e7eb] bg-white text-[#374151] text-sm cursor-pointer"
+                >
+                    취소
+                </button>
+                <button
+                    onClick={() => void handleCreate()}
+                    disabled={!pageName.trim() || creating || !canWrite}
+                    className={`px-5 py-2 rounded-lg text-sm font-semibold text-white ${
+                        !pageName.trim() || creating || !canWrite
+                            ? 'bg-[#93c5fd] cursor-not-allowed'
+                            : 'bg-[#0046A4] cursor-pointer'
+                    }`}
+                >
+                    {creating ? '생성 중...' : '만들기'}
+                </button>
+            </div>
+        </Modal>
+    );
+}

--- a/src/db/queries/page.sql.ts
+++ b/src/db/queries/page.sql.ts
@@ -259,6 +259,15 @@ export const PAGE_SELECT_HTML_BY_ID = `
     AND USE_YN = 'Y'
 `;
 
+/** 페이지 생성 모달용 템플릿 목록 조회 */
+export const PAGE_SELECT_TEMPLATE_LIST = `
+  SELECT PAGE_ID, PAGE_NAME
+  FROM SPW_CMS_PAGE
+  WHERE PAGE_TYPE = 'TEMPLATE'
+    AND USE_YN = 'Y'
+  ORDER BY PAGE_NAME
+`;
+
 /** PAGE_HTML 업데이트 (에디터 HTML → DB CLOB 직접 저장) */
 export const PAGE_UPDATE_HTML = `
   UPDATE SPW_CMS_PAGE

--- a/src/db/repository/page.repository.ts
+++ b/src/db/repository/page.repository.ts
@@ -28,6 +28,7 @@ import {
     PAGE_ROLLBACK,
     PAGE_SELECT_AB_GROUP,
     PAGE_SELECT_HTML_BY_ID,
+    PAGE_SELECT_TEMPLATE_LIST,
     PAGE_UPDATE_HTML,
     PAGE_UPDATE_AB_GROUP,
     PAGE_CLEAR_AB_GROUP,
@@ -49,6 +50,11 @@ import { ASSET_MAP_INSERT, ASSET_MAP_DELETE_BY_PAGE_VERSION } from '@/db/queries
 import { readPageHtml } from '@/lib/page-file';
 
 const OBJ = { outFormat: oracledb.OUT_FORMAT_OBJECT };
+
+export interface CmsPageTemplateSummary {
+    pageId: string;
+    pageName: string;
+}
 
 // ═══════════════════════════════════════════════
 // 페이지 조회
@@ -133,6 +139,20 @@ export async function getPageHtml(pageId: string): Promise<string | null> {
     try {
         const result = await conn.execute<{ PAGE_HTML: string | null }>(PAGE_SELECT_HTML_BY_ID, { pageId }, OBJ);
         return result.rows?.[0]?.PAGE_HTML ?? null;
+    } finally {
+        await conn.close();
+    }
+}
+
+/** 페이지 생성 모달용 템플릿 목록 조회 */
+export async function getPageTemplateList(): Promise<CmsPageTemplateSummary[]> {
+    const conn = await getConnection();
+    try {
+        const result = await conn.execute<{ PAGE_ID: string; PAGE_NAME: string }>(PAGE_SELECT_TEMPLATE_LIST, {}, OBJ);
+        return (result.rows ?? []).map((row) => ({
+            pageId: row.PAGE_ID,
+            pageName: row.PAGE_NAME,
+        }));
     } finally {
         await conn.close();
     }

--- a/src/lib/cms-page-create.ts
+++ b/src/lib/cms-page-create.ts
@@ -1,0 +1,42 @@
+import { nextApi } from '@/lib/api-url';
+
+export type CmsPageViewMode = 'mobile' | 'web' | 'responsive';
+
+export interface CreateCmsPageInput {
+    pageName: string;
+    viewMode: CmsPageViewMode;
+    templateId?: string;
+}
+
+export interface CreateCmsPageResult {
+    pageId: string;
+    editorUrl: string;
+}
+
+export async function createCmsPage(input: CreateCmsPageInput): Promise<CreateCmsPageResult> {
+    const pageName = input.pageName.trim();
+    if (!pageName) {
+        throw new Error('페이지명을 입력하세요.');
+    }
+
+    const res = await fetch(nextApi('/api/builder/save'), {
+        method: 'POST',
+        body: JSON.stringify({
+            html: '',
+            pageName,
+            viewMode: input.viewMode,
+            templateId: input.templateId ?? 'blank',
+        }),
+        headers: { 'Content-Type': 'application/json' },
+    });
+    const data = await res.json();
+
+    if (!res.ok || !data.ok || !data.pageId) {
+        throw new Error(data.error || '페이지 생성에 실패했습니다.');
+    }
+
+    return {
+        pageId: data.pageId,
+        editorUrl: typeof data.editorUrl === 'string' ? data.editorUrl : nextApi(`/edit?bank=${data.pageId}`),
+    };
+}


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issues)
- #69

## ✨ 변경 사항 (Changes)
- `/cms/dashboard`와 `/cms/edit`의 새페이지 생성 로직을 공통화했습니다.
- 공통 클라이언트 생성 함수 `src/lib/cms-page-create.ts`를 추가해 두 화면이 동일한 생성 API 흐름을 사용하도록 정리했습니다.
- 새페이지 생성 모달을 공통 컴포넌트 `src/components/ui/CreatePageModal.tsx`로 분리해 `/cms/dashboard`, `/cms/edit`에서 동일한 UI/동작을 사용하도록 변경했습니다.
- `POC_HNC/admin`과 동일하게 `PAGE_TYPE='TEMPLATE'`인 페이지를 템플릿 목록으로 조회하고, 선택한 템플릿의 `PAGE_HTML`을 새 페이지 생성 시 복사하도록 구현했습니다.
- 템플릿 목록 조회용 API `GET /api/builder/templates`를 추가했습니다.
- 새페이지 생성 API(`/api/builder/save`)에서 서버가 `pageId`를 생성하고 `editorUrl`을 반환하도록 보강했습니다.
- `/cms/edit` 상단 탭 링크가 base path(`/cms`)를 타지 않던 문제를 함께 수정했습니다.
- 신규 페이지 생성 시 불필요한 기존 페이지 조회를 생략해 DB 커넥션 사용을 줄이도록 조정했습니다.

## 📸 변경 사항 확인 (선택)

| 변경 전 (Before) | 변경 후 (After) |
| :--- | :--- |
| `/cms/dashboard`와 `/cms/edit`의 새페이지 생성 UI/로직이 분리되어 있었음 | 두 화면 모두 동일한 공통 모달/공통 생성 로직 사용 |
| 대시보드에서는 템플릿 선택 불가 | 대시보드/에디터 모두 `PAGE_TYPE='TEMPLATE'` 기반 템플릿 선택 가능 |
| 에디터 상단 생성은 클라이언트에서 UUID 생성 | 서버가 `pageId` 생성 후 `editorUrl` 반환 |

## ⚠️ 고려 및 주의 사항 (선택)
- 템플릿 목록은 `SPW_CMS_PAGE`에서 `PAGE_TYPE='TEMPLATE' AND USE_YN='Y'` 조건으로 조회합니다. 운영 DB에 템플릿 페이지가 없으면 모달에는 `빈 페이지`만 표시됩니다.
- 현재 새페이지 생성은 배포 서버 직접 저장이 아니라 CMS DB(`PAGE_HTML`) 저장 기준입니다. 실제 배포 반영은 기존 승인/배포 플로우를 따릅니다.
- Oracle 세션이 부족한 환경에서는 기존과 마찬가지로 `ORA-12516`이 발생할 수 있습니다. 이번 변경에서 신규 페이지 생성 시 기존 페이지 조회를 생략해 커넥션 사용량은 일부 줄였습니다.

## 💬 리뷰 포인트 (선택)
- `POC_HNC/admin`의 템플릿 생성 방식과 비교했을 때, 현재 `/api/builder/save`에서 템플릿 검증 및 `PAGE_HTML` 복사 위치가 적절한지 봐주시면 좋겠습니다.
- `CreatePageModal` 공통화로 인해 `/cms/dashboard`, `/cms/edit`의 새페이지 생성 UX가 의도대로 일관되게 맞춰졌는지 확인 부탁드립니다.
- `/cms/edit` 상단 탭 링크를 `nextApi('/edit?...')`로 바꾼 부분이 base path 운영 환경에서 문제 없는지 함께 확인 부탁드립니다.

## 🔗 참고 사항 (선택)
- 관련 커밋: `13838b2 feat #69 : 템플릿 기반 새페이지 생성 공통화`
- 빌드 검증: `npm run build` 성공